### PR TITLE
feat: only have `standard` fuels and `credit` prices enabled by default

### DIFF
--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -102,10 +102,10 @@ async def async_migrate_entry(hass, config_entry) -> bool:
         if CONF_UOM not in updated_config.keys():
             updated_config[CONF_UOM] = True
 
-
-
     if updated_config != config_entry.data:
-        hass.config_entries.async_update_entry(config_entry, data=updated_config, version=new_version)
+        hass.config_entries.async_update_entry(
+            config_entry, data=updated_config, version=new_version
+        )
 
     _LOGGER.debug("Migration to version %s complete", CONFIG_VER)
 

--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_INTERVAL,
     CONF_STATION_ID,
     CONF_UOM,
+    CONFIG_VER,
     COORDINATOR,
     DOMAIN,
     ISSUE_URL,
@@ -90,6 +91,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
 async def async_migrate_entry(hass, config_entry) -> bool:
     """Migrate an old config entry."""
     version = config_entry.version
+    new_version = CONFIG_VER
 
     # 1 -> 2: Migrate format
     if version == 1:
@@ -100,11 +102,12 @@ async def async_migrate_entry(hass, config_entry) -> bool:
         if CONF_UOM not in updated_config.keys():
             updated_config[CONF_UOM] = True
 
-        if updated_config != config_entry.data:
-            hass.config_entries.async_update_entry(config_entry, data=updated_config)
 
-        config_entry.version = 4
-        _LOGGER.debug("Migration to version %s complete", config_entry.version)
+
+    if updated_config != config_entry.data:
+        hass.config_entries.async_update_entry(config_entry, data=updated_config, version=new_version)
+
+    _LOGGER.debug("Migration to version %s complete", CONFIG_VER)
 
     return True
 

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -14,6 +14,7 @@ CONF_POSTAL = "zipcode"
 CONF_UOM = "uom"
 DEFAULT_INTERVAL = 3600
 DEFAULT_NAME = "Gas Station"
+CONFIG_VER = 4
 
 # hass.data attribues
 COORDINATOR = "coordinator"

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -53,6 +53,7 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="Diesel",
         icon="mdi:gas-station",
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
     ),
     "regular_gas_cash": GasBuddySensorEntityDescription(
         key="regular_gas",
@@ -60,6 +61,7 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         cash=True,
         icon="mdi:gas-station",
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
     ),
     "midgrade_gas_cash": GasBuddySensorEntityDescription(
         key="midgrade_gas",
@@ -67,6 +69,7 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         cash=True,
         icon="mdi:gas-station",
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
     ),
     "premium_gas_cash": GasBuddySensorEntityDescription(
         key="premium_gas",
@@ -74,6 +77,7 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         cash=True,
         icon="mdi:gas-station",
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
     ),
     "diesel_cash": GasBuddySensorEntityDescription(
         key="diesel",
@@ -81,5 +85,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         cash=True,
         icon="mdi:gas-station",
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
     ),
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,13 +20,13 @@ async def test_setup_and_unload_entry(hass, mock_gasbuddy):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 
     assert await hass.config_entries.async_remove(entries[0].entry_id)
@@ -44,13 +44,13 @@ async def test_setup_and_unload_entry_v1(hass, mock_gasbuddy):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 
     assert await hass.config_entries.async_remove(entries[0].entry_id)


### PR DESCRIPTION
fixes #82 