### PR TITLE
chore: remove py313 and update workflows to latest

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # @v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6
 
       - name: Get Version
         id: get_version
@@ -41,13 +41,13 @@ jobs:
 
       - name: 📤 Upload zip to release
         if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # @v3
         with:
           files: ${{ github.workspace }}/custom_components/gasbuddy/ha-gasbuddy.zip
 
       - name: 📤 Upload zip to release
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # @v3
         with:
           files: ${{ github.workspace }}/custom_components/gasbuddy/ha-gasbuddy.zip
           tag_name: ${{inputs.tags}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get Version
         id: get_version
@@ -41,13 +41,13 @@ jobs:
 
       - name: 📤 Upload zip to release
         if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ github.workspace }}/custom_components/gasbuddy/ha-gasbuddy.zip
 
       - name: 📤 Upload zip to release
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ github.workspace }}/custom_components/gasbuddy/ha-gasbuddy.zip
           tag_name: ${{inputs.tags}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     name: Pre-commit
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🛠️ Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: 🔍 Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
@@ -37,15 +37,14 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.13"
           - "3.14"
 
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🛠️ Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -61,7 +60,7 @@ jobs:
         run: tox
 
       - name: 📤 Upload coverage to Codecov
-        uses: "actions/upload-artifact@v4"
+        uses: "actions/upload-artifact@v6"
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: "coverage.xml"
@@ -71,15 +70,15 @@ jobs:
     needs: tests
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: 📥 Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: coverage-data-*
           merge-multiple: true
       - name: 📤 Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🛠️ Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -60,7 +60,7 @@ jobs:
         run: tox
 
       - name: 📤 Upload coverage to Codecov
-        uses: "actions/upload-artifact@v6"
+        uses: "actions/upload-artifact@v7"
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: "coverage.xml"
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: 📥 Download coverage data
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-data-*
           merge-multiple: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     name: Pre-commit
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6
 
       - name: 🛠️ Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # @v6
         with:
           python-version: "3.14"
 
       - name: 🔍 Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # @v3.0.1
 
       - name: 🔍 Hassfest validation
         uses: "home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b"
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6
 
       - name: 🛠️ Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # @v7
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -60,7 +60,7 @@ jobs:
         run: tox
 
       - name: 📤 Upload coverage to Codecov
-        uses: "actions/upload-artifact@v7"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # @v7
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: "coverage.xml"
@@ -70,15 +70,15 @@ jobs:
     needs: tests
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6
         with:
           fetch-depth: 2
       - name: 📥 Download coverage data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # @v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
       - name: 📤 Upload coverage report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # @v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.7
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,7 +361,7 @@ line-length = 100
 indent-width = 4
 fix = true
 force-exclude = true
-target-version = "py314"
+target-version = "py313"
 required-version = ">=0.8.0"
 preview = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,7 +361,7 @@ line-length = 100
 indent-width = 4
 fix = true
 force-exclude = true
-target-version = "py313"
+target-version = "py314"
 required-version = ">=0.8.0"
 preview = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ fail_under = 80
 
 [tool.mypy]
 platform = "linux"
-python_version = "3.13"
+python_version = "3.14"
 follow_imports = "silent"
 ignore_missing_imports = true
 check_untyped_defs = true
@@ -615,7 +615,6 @@ property-decorators = ["propcache.cached_property"]
 
 [tool.tox.gh-actions]
 python = """
-    3.13: py313, lint, mypy
     3.14: py314, lint, mypy
 """
 


### PR DESCRIPTION
This PR removes Python 3.13 from the test matrix and project configuration, targeting Python 3.14 instead.
It also updates all GitHub Actions (except HACS) to their latest major versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows and GitHub Actions to newer releases for improved reliability.
  * Modernized the release workflow upload behavior and release drafting.
  * Upgraded test and build tooling to target Python 3.14 across CI and project configuration.
  * Bumped pre-commit tooling and project toolchain targets to align with Python 3.14.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/230)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/230)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->