### PR TITLE
chore: add permissions to release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,10 @@ on:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit permissions to the `release-drafter` workflow. This is required for the action to be able to automatically label pull requests and update release drafts, especially in repositories with restricted default `GITHUB_TOKEN` permissions.

Permissions added:
- `contents: write` (for updating release drafts)
- `pull-requests: write` (for labeling pull requests)