### PR TITLE
fix: test autolabeler with simple fix prefix

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,21 +4,33 @@ change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 autolabeler:
   - label: "chore"
+    branch:
+      - "/^chore-.*/i"
     title:
       - "/^chore(\\s*\\(.*\\))?:/i"
   - label: "bugfix"
+    branch:
+      - "/^fix-.*/i"
     title:
       - "/^fix(\\s*\\(.*\\))?:/i"
   - label: "feature"
+    branch:
+      - "/^feat-.*/i"
     title:
       - "/^feat(\\s*\\(.*\\))?:/i"
   - label: "enhancement"
+    branch:
+      - "/^refactor-.*/i"
     title:
       - "/^refactor(\\s*\\(.*\\))?:/i"
   - label: "code-quality"
+    branch:
+      - "/^test-.*/i"
     title:
       - "/^test(s)?(\\s*\\(.*\\))?:/i"
   - label: "dependencies"
+    branch:
+      - "/^deps-.*/i"
     title:
       - "/^build\\(deps\\):/i"
 categories:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,22 +5,22 @@ sort-direction: ascending
 autolabeler:
   - label: "chore"
     title:
-      - "/chore:/i"
+      - "/^chore(\\s*\\(.*\\))?:/i"
   - label: "bugfix"
     title:
-      - "/fix:/i"
+      - "/^fix(\\s*\\(.*\\))?:/i"
   - label: "feature"
     title:
-      - "/feat:/i"
+      - "/^feat(\\s*\\(.*\\))?:/i"
   - label: "enhancement"
     title:
-      - "/refactor:/i"
+      - "/^refactor(\\s*\\(.*\\))?:/i"
   - label: "code-quality"
     title:
-      - "/tests:/i"
+      - "/^test(s)?(\\s*\\(.*\\))?:/i"
   - label: "dependencies"
     title:
-      - "/build(deps):/i"
+      - "/^build\\(deps\\):/i"
 categories:
   - title: "💥 Breaking Change 💥"
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
       - dev
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR improves the autolabeler configuration to be more robust and responsive.

Changes:
- Added `edited` trigger to the release-drafter workflow so labels update immediately when PR titles are changed.
- Hardened autolabeler regex patterns to correctly handle optional scopes (e.g., `feat(ui):`).
- Added branch name matching as a fallback for labeling.