### PR TITLE
chore: improve autolabeler robustness and add fallback labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# This file configures the actions/labeler GitHub Action.
+# It automatically adds labels to pull requests based on the head branch name
+# or the files that have been changed.
+
+chore:
+  - head-branch: ['^chore-.*', '^docs-.*']
+
+bugfix:
+  - head-branch: ['^fix-.*']
+
+feature:
+  - head-branch: ['^feat-.*']
+
+documentation:
+  - head-branch: ['^docs-.*']
+  - changed-files:
+      - any-glob-to-any-file: ['README.md', 'docs/**', 'CONTRIBUTING.md']
+
+dependencies:
+  - head-branch: ['^deps-.*', '^dependabot/.*']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,39 +5,39 @@ sort-direction: ascending
 autolabeler:
   - label: "chore"
     branch:
-      - "/^chore-.*/i"
-      - "/^docs-.*/i"
+      - "chore-*"
+      - "docs-*"
     title:
       - "/^chore(\\s*\\(.*\\))?:/i"
       - "/^docs(\\s*\\(.*\\))?:/i"
   - label: "documentation"
     branch:
-      - "/^docs-.*/i"
+      - "docs-*"
     title:
       - "/^docs(\\s*\\(.*\\))?:/i"
   - label: "bugfix"
     branch:
-      - "/^fix-.*/i"
+      - "fix-*"
     title:
       - "/^fix(\\s*\\(.*\\))?:/i"
   - label: "feature"
     branch:
-      - "/^feat-.*/i"
+      - "feat-*"
     title:
       - "/^feat(\\s*\\(.*\\))?:/i"
   - label: "enhancement"
     branch:
-      - "/^refactor-.*/i"
+      - "refactor-*"
     title:
       - "/^refactor(\\s*\\(.*\\))?:/i"
   - label: "code-quality"
     branch:
-      - "/^test-.*/i"
+      - "test-*"
     title:
       - "/^test(s)?(\\s*\\(.*\\))?:/i"
   - label: "dependencies"
     branch:
-      - "/^deps-.*/i"
+      - "deps-*"
     title:
       - "/^build\\(deps\\):/i"
       - "/^chore\\(deps\\):/i"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,8 +6,15 @@ autolabeler:
   - label: "chore"
     branch:
       - "/^chore-.*/i"
+      - "/^docs-.*/i"
     title:
       - "/^chore(\\s*\\(.*\\))?:/i"
+      - "/^docs(\\s*\\(.*\\))?:/i"
+  - label: "documentation"
+    branch:
+      - "/^docs-.*/i"
+    title:
+      - "/^docs(\\s*\\(.*\\))?:/i"
   - label: "bugfix"
     branch:
       - "/^fix-.*/i"
@@ -33,6 +40,7 @@ autolabeler:
       - "/^deps-.*/i"
     title:
       - "/^build\\(deps\\):/i"
+      - "/^chore\\(deps\\):/i"
 categories:
   - title: "💥 Breaking Change 💥"
     labels:
@@ -51,6 +59,8 @@ categories:
   - title: "🔧 Maintenance 🔧"
     labels:
       - "chore"
+      - "docs"
+      - "documentation"
     collapse-after: 3
   - title: "🎓 Code Quality 🎓"
     labels:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on:
-  - pull_request_target
+  - pull_request
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Label the PR
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # @v6
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
This PR improves the autolabeler system to ensure consistent and robust PR labeling.

Changes:
- Added **`actions/labeler`** as a fallback system. This official action is highly reliable for branch and file-based labeling and reads its configuration from the PR branch, making it easier to test.
- Refined the **`release-drafter`** configuration:
  - Consolidated `chore` mappings and added support for `docs:` title and `docs-` branch patterns.
  - Added a dedicated `documentation` label mapping.
  - Updated `dependencies` mapping to correctly identify `chore(deps):` titles.
- Pin all actions to their **latest stable SHAs** for enhanced security and reliability.

These improvements ensure that PRs are correctly categorized both in the PR view and in the automatically generated release notes.