### PR TITLE
feat(sensor): enable default EV sensors and add website attribute to EV network sensor

### DIFF
--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -188,7 +188,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV J1772 Connectors",
         icon="mdi:ev-station",
         price=False,
-        entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "ev_j1772_power": GasBuddySensorEntityDescription(
@@ -203,7 +202,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV CCS Connectors",
         icon="mdi:ev-station",
         price=False,
-        entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "ev_ccs_power": GasBuddySensorEntityDescription(
@@ -218,7 +216,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV CHAdeMO Connectors",
         icon="mdi:ev-station",
         price=False,
-        entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "ev_chademo_power": GasBuddySensorEntityDescription(
@@ -233,7 +230,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV NACS Connectors",
         icon="mdi:ev-station",
         price=False,
-        entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "ev_nacs_power": GasBuddySensorEntityDescription(
@@ -280,7 +276,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV Access",
         icon="mdi:lock-open-outline",
         price=False,
-        entity_registry_enabled_default=False,
     ),
     "ev_cards_accepted": GasBuddySensorEntityDescription(
         key="ev_cards_accepted",
@@ -294,6 +289,5 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV Last Confirmed",
         icon="mdi:calendar-check",
         price=False,
-        entity_registry_enabled_default=False,
     ),
 }

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -141,6 +141,8 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
                 attrs["distance_miles"] = data.get("ev_distance_miles")
             if data.get("ev_network") is not None:
                 attrs["network"] = data.get("ev_network")
+            if self._type == "ev_network" and data.get("ev_network_web") is not None:
+                attrs["website"] = data.get("ev_network_web")
             if data.get("ev_pricing") is not None:
                 attrs["pricing"] = data.get("ev_pricing")
             if data.get("ev_access_hours") is not None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -288,6 +288,7 @@ async def test_ev_sensors(hass, mock_gasbuddy, integration):
         "ev_station_address": "1101 N Verrado Way",
         "ev_distance_miles": 1.5,
         "ev_network": "Costco",
+        "ev_network_web": "https://costco.com",
         "ev_pricing": "Free",
         "ev_access_hours": "24/7",
         "latitude": 33.459108,
@@ -309,6 +310,14 @@ async def test_ev_sensors(hass, mock_gasbuddy, integration):
         assert attrs["access_hours"] == "24/7"
         assert attrs[ATTR_LATITUDE] == 33.459108
         assert attrs[ATTR_LONGITUDE] == -112.502745
+        assert "website" not in attrs
+
+        # Test ev_network sensor which has the website attribute
+        sensor_web = GasBuddySensor(SENSOR_TYPES["ev_network"], coordinator, integration)
+        attrs_web = sensor_web.extra_state_attributes
+        assert attrs_web is not None
+        assert attrs_web["network"] == "Costco"
+        assert attrs_web["website"] == "https://costco.com"
 
 
 async def test_sensors_ev_only(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):


### PR DESCRIPTION
This PR implements the requested changes for EV sensors:
- Enables the following EV sensors by default:
  - EV Last Confirmed (`ev_date_last_confirmed`)
  - EV Access (`ev_access_code`)
  - EV J1772 Connectors (`ev_j1772`)
  - EV CCS Connectors (`ev_ccs`)
  - EV CHAdeMO Connectors (`ev_chademo`)
  - EV NACS Connectors (`ev_nacs`)
- Adds the EV network website (`ev_network_web` coordinator data) as a `website` attribute on the EV Charging Network (`ev_network`) sensor.
- Updates tests to cover the new `website` attribute on `ev_network` and verify it is not present on other EV sensors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EV network sensor now displays website information when available.

* **Improvements**
  * EV connector sensors (J1772, CCS, CHAdeMO, NACS) are now enabled by default in the entity registry for improved discoverability.
  * Updated sensor metadata for enhanced system integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->