### PR TITLE
feat(sensor): update ev_date_last_confirmed to timestamp and make ev_access_code translatable

### DIFF
--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -276,6 +276,7 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV Access",
         icon="mdi:lock-open-outline",
         price=False,
+        translation_key="ev_access",
     ),
     "ev_cards_accepted": GasBuddySensorEntityDescription(
         key="ev_cards_accepted",
@@ -289,5 +290,6 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         name="EV Last Confirmed",
         icon="mdi:calendar-check",
         price=False,
+        device_class=SensorDeviceClass.TIMESTAMP,
     ),
 }

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import as_utc, parse_datetime
 
 from .const import (
     ATTR_IMAGEURL,
@@ -89,7 +90,15 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
             return None
 
         if not self._price:
-            return data.get(self._type)
+            val = data.get(self._type)
+            if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP and isinstance(
+                val, str
+            ):
+                if parsed := parse_datetime(val):
+                    return as_utc(parsed)
+            if self.entity_description.translation_key == "ev_access" and isinstance(val, str):
+                return val.lower()
+            return val
 
         if self._cash:
             price = data[self._type].get("cash_price")

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -96,6 +96,8 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
             ):
                 if parsed := parse_datetime(val):
                     return as_utc(parsed)
+                _LOGGER.warning("Failed to parse timestamp for %s: %s", self._type, val)
+                return None
             if self.entity_description.translation_key == "ev_access" and isinstance(val, str):
                 return val.lower()
             return val

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -76,5 +76,16 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "ev_access": {
+                "state": {
+                    "public": "Public",
+                    "private": "Private",
+                    "none": "None"
+                }
+            }
+        }
     }
 }

--- a/custom_components/gasbuddy/translations/en.json
+++ b/custom_components/gasbuddy/translations/en.json
@@ -76,5 +76,16 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "ev_access": {
+                "state": {
+                    "public": "Public",
+                    "private": "Private",
+                    "none": "None"
+                }
+            }
+        }
     }
 }

--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -76,5 +76,16 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "ev_access": {
+                "state": {
+                    "public": "Public",
+                    "private": "Privé",
+                    "none": "Aucun"
+                }
+            }
+        }
     }
 }

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -76,5 +76,16 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "ev_access": {
+                "state": {
+                    "public": "Público",
+                    "private": "Privado",
+                    "none": "Nenhum"
+                }
+            }
+        }
     }
 }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -328,6 +328,10 @@ async def test_ev_sensors(hass, mock_gasbuddy, integration):
         )
         assert sensor_date.native_value == as_utc(parse_datetime("2026-05-18"))
 
+        # Test invalid date string for TIMESTAMP sensor returns None
+        with patch.dict(coordinator.data, {"ev_date_last_confirmed": "invalid-date"}):
+            assert sensor_date.native_value is None
+
         # Test ev_access_code sensor
         sensor_access = GasBuddySensor(SENSOR_TYPES["ev_access_code"], coordinator, integration)
         assert sensor_access.native_value == "none"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,6 +24,7 @@ from custom_components.gasbuddy.sensor import GasBuddySensor
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.dt import as_utc, parse_datetime
 from tests.common import load_fixture
 
 from .const import CONFIG_DATA, CONFIG_DATA_NO_UOM, OPTIONS_NO_UOM
@@ -293,6 +294,8 @@ async def test_ev_sensors(hass, mock_gasbuddy, integration):
         "ev_access_hours": "24/7",
         "latitude": 33.459108,
         "longitude": -112.502745,
+        "ev_date_last_confirmed": "2026-05-18",
+        "ev_access_code": "None",
     }
 
     with patch.dict(coordinator.data, ev_data):
@@ -318,6 +321,16 @@ async def test_ev_sensors(hass, mock_gasbuddy, integration):
         assert attrs_web is not None
         assert attrs_web["network"] == "Costco"
         assert attrs_web["website"] == "https://costco.com"
+
+        # Test ev_date_last_confirmed sensor
+        sensor_date = GasBuddySensor(
+            SENSOR_TYPES["ev_date_last_confirmed"], coordinator, integration
+        )
+        assert sensor_date.native_value == as_utc(parse_datetime("2026-05-18"))
+
+        # Test ev_access_code sensor
+        sensor_access = GasBuddySensor(SENSOR_TYPES["ev_access_code"], coordinator, integration)
+        assert sensor_access.native_value == "none"
 
 
 async def test_sensors_ev_only(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):


### PR DESCRIPTION
This PR implements the following changes:
- Updates the `ev_date_last_confirmed` sensor to use `SensorDeviceClass.TIMESTAMP` and parses the date string into a timezone-aware UTC datetime.
- Configures `ev_access_code` to be translatable by adding `translation_key="ev_access"` and downcasing the returned state string.
- Registers translations for the new sensor states in `strings.json` and the corresponding localized JSON files (`en.json`, `fr.json`, `pt.json`).
- Updates unit tests to assert the correct formatting and datatypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EV charging access sensor shows localized state labels (public, private, none) in English, French, and Portuguese.
  * EV date confirmation sensor now parses and displays timestamp values consistently (UTC).
* **Bug Fixes**
  * EV access values are normalized (case-insensitive) to stable state labels.
* **Tests**
  * Added tests verifying timestamp parsing, invalid-date handling, and access-value normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->