### PR TITLE
feat: deal price sensors, dynamic enabled_default, richer attributes, cheapest gas mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -742,6 +742,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
             postal = (user_input.get(CONF_POSTAL) or "").strip()
             if postal:
+                if not _POSTAL_RE.match(postal):
+                    self._errors[CONF_POSTAL] = "no_results"
+                    return await self._show_config_cheapest(user_input)
                 data[CONF_POSTAL] = postal
 
             return self.async_create_entry(
@@ -838,6 +841,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
             postal = (user_input.get(CONF_POSTAL) or "").strip()
             if postal:
+                if not _POSTAL_RE.match(postal):
+                    self._errors[CONF_POSTAL] = "no_results"
+                    return await self._show_reconfig_cheapest_form(user_input)
                 new_data[CONF_POSTAL] = postal
             else:
                 new_data.pop(CONF_POSTAL, None)

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig, SelectSelectorMode
 
 from .const import (
     CONF_CHEAPEST,
@@ -40,6 +41,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_STATION_ID_RE = re.compile(r"^\d{1,20}$")
+_POSTAL_RE = re.compile(r"^\d{5}(-\d{4})?$|^[A-Za-z]\d[A-Za-z] ?\d[A-Za-z]\d$")
 MENU_OPTIONS = ["manual", "search", "cheapest"]
 MENU_SEARCH = ["home", "postal"]
 
@@ -237,7 +240,7 @@ def _get_schema_manual(  # pylint: disable-next=unused-argument
 
     return vol.Schema({
         vol.Required(CONF_STATION_ID, default=_get_default(CONF_STATION_ID)): vol.All(
-            cv.string, vol.Strip, vol.Match(r"^\d{1,20}$")
+            cv.string, vol.Strip
         ),
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
             cv.string, vol.Strip, vol.Length(max=100)
@@ -309,9 +312,7 @@ def _get_schema_postal(  # pylint: disable-next=unused-argument
 
     return vol.Schema({
         vol.Required(CONF_POSTAL, default=_get_default(CONF_POSTAL)): vol.All(
-            vol.Coerce(str),
-            vol.Strip,
-            vol.Match(r"^\d{5}(-\d{4})?$|^[A-Za-z]\d[A-Za-z] ?\d[A-Za-z]\d$"),
+            vol.Coerce(str), vol.Strip
         ),
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
@@ -362,11 +363,17 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
         vol.Optional(CONF_POSTAL, default=_get_default(CONF_POSTAL, "")): vol.All(
             vol.Coerce(str), vol.Strip
         ),
-        vol.Required(CONF_FUEL_KEY, default=_get_default(CONF_FUEL_KEY, "regular_gas")): vol.In(
-            FUEL_KEY_CHOICES
+        vol.Required(CONF_FUEL_KEY, default=_get_default(CONF_FUEL_KEY, "regular_gas")): SelectSelector(
+            SelectSelectorConfig(
+                options=[{"value": k, "label": v} for k, v in FUEL_KEY_CHOICES.items()],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
         ),
-        vol.Required(CONF_PRICE_TYPE, default=_get_default(CONF_PRICE_TYPE, "best")): vol.In(
-            PRICE_TYPE_CHOICES
+        vol.Required(CONF_PRICE_TYPE, default=_get_default(CONF_PRICE_TYPE, "best")): SelectSelector(
+            SelectSelectorConfig(
+                options=[{"value": k, "label": v} for k, v in PRICE_TYPE_CHOICES.items()],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
         ),
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
@@ -434,6 +441,11 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 if not url_valid:
                     self._errors[CONF_SOLVER] = "invalid_url"
                     return await self._show_config_manual(user_input)
+
+            station_id = str(user_input.get(CONF_STATION_ID, "")).strip()
+            if not _STATION_ID_RE.match(station_id):
+                self._errors[CONF_STATION_ID] = "station_id"
+                return await self._show_config_manual(user_input)
 
             try:
                 validate = await validate_station(
@@ -601,6 +613,11 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._data.update(user_input)
+            postal = str(user_input.get(CONF_POSTAL, "")).strip()
+            if not _POSTAL_RE.match(postal):
+                self._errors[CONF_POSTAL] = "no_results"
+                return await self._show_config_postal(user_input)
+
             if user_input.get(CONF_SOLVER):
                 url_valid = validate_url(user_input[CONF_SOLVER])
                 _LOGGER.debug("URL valid: %s", url_valid)
@@ -755,6 +772,11 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._data.update(user_input)
+            station_id = str(user_input.get(CONF_STATION_ID, "")).strip()
+            if not _STATION_ID_RE.match(station_id):
+                self._errors[CONF_STATION_ID] = "station_id"
+                return await self._show_reconfig_form(user_input)
+
             if user_input[CONF_SOLVER] != "":
                 url_valid = validate_url(user_input[CONF_SOLVER])
                 _LOGGER.debug("URL valid: %s", url_valid)

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -789,6 +789,7 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("URL valid: %s", url_valid)
                 if not url_valid:
                     self._errors[CONF_SOLVER] = "invalid_url"
+                    return await self._show_reconfig_form(user_input)
             else:
                 user_input[CONF_SOLVER] = None
 

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -18,12 +18,15 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
+    CONF_CHEAPEST,
     CONF_EV_CHARGING,
     CONF_FETCH_GAS,
+    CONF_FUEL_KEY,
     CONF_GPS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_POSTAL,
+    CONF_PRICE_TYPE,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -32,10 +35,12 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_TIMEOUT,
     DOMAIN,
+    FUEL_KEY_CHOICES,
+    PRICE_TYPE_CHOICES,
 )
 
 _LOGGER = logging.getLogger(__name__)
-MENU_OPTIONS = ["manual", "search"]
+MENU_OPTIONS = ["manual", "search", "cheapest"]
 MENU_SEARCH = ["home", "postal"]
 
 
@@ -333,6 +338,39 @@ def _get_schema_station_list(
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
             cv.string, vol.Strip
         ),
+    })
+
+
+def _get_schema_cheapest(  # pylint: disable-next=unused-argument
+    hass: Any, user_input: dict[str, Any], default_dict: dict[str, Any]
+) -> Any:
+    """Get a schema for the cheapest gas tracker setup."""
+    if user_input is None:
+        user_input = {}
+
+    def _get_default(key: str, fallback_default: Any = None) -> Any | None:
+        """Get default value for key."""
+        return user_input.get(key, default_dict.get(key, fallback_default))
+
+    return vol.Schema({
+        vol.Required(CONF_NAME, default=_get_default(CONF_NAME, "Cheapest Gas")): vol.All(
+            cv.string, vol.Strip
+        ),
+        vol.Optional(CONF_POSTAL, default=_get_default(CONF_POSTAL, "")): vol.All(
+            vol.Coerce(str), vol.Strip
+        ),
+        vol.Required(CONF_FUEL_KEY, default=_get_default(CONF_FUEL_KEY, "regular_gas")): vol.In(
+            FUEL_KEY_CHOICES
+        ),
+        vol.Required(CONF_PRICE_TYPE, default=_get_default(CONF_PRICE_TYPE, "best")): vol.In(
+            PRICE_TYPE_CHOICES
+        ),
+        vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
+            cv.string, vol.Strip
+        ),
+        vol.Optional(
+            CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+        ): cv.positive_int,
     })
 
 
@@ -651,12 +689,60 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
+    # Cheapest Nearby Gas
+    async def async_step_cheapest(self, user_input=None):
+        """Handle the cheapest gas tracker flow."""
+        self._errors = {}
+
+        if user_input is not None:
+            solver = (user_input.get(CONF_SOLVER) or "").strip() or None
+            if solver:
+                url_valid = await validate_url(solver)
+                if not url_valid:
+                    self._errors[CONF_SOLVER] = "invalid_url"
+                    return await self._show_config_cheapest(user_input)
+
+            data: dict[str, Any] = {
+                CONF_NAME: user_input[CONF_NAME],
+                CONF_CHEAPEST: True,
+                CONF_FUEL_KEY: user_input[CONF_FUEL_KEY],
+                CONF_PRICE_TYPE: user_input[CONF_PRICE_TYPE],
+                CONF_SOLVER: solver,
+                CONF_TIMEOUT: user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            }
+            postal = (user_input.get(CONF_POSTAL) or "").strip()
+            if postal:
+                data[CONF_POSTAL] = postal
+
+            return self.async_create_entry(
+                title=data[CONF_NAME],
+                data=data,
+                options={
+                    CONF_INTERVAL: 3600,
+                    CONF_UOM: True,
+                    CONF_GPS: False,
+                    CONF_EV_CHARGING: False,
+                    CONF_FETCH_GAS: True,
+                },
+            )
+        return await self._show_config_cheapest(user_input)
+
+    async def _show_config_cheapest(self, user_input):
+        """Show the cheapest gas tracker configuration form."""
+        return self.async_show_form(
+            step_id="cheapest",
+            data_schema=_get_schema_cheapest(self.hass, user_input, {}),
+            errors=self._errors,
+        )
+
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
         """Add reconfigure step to allow to reconfigure a config entry."""
         entry = self._get_reconfigure_entry()
-        # assert self._entry
         self._data = dict(entry.data)
         self._errors = {}
+
+        if entry.data.get(CONF_CHEAPEST):
+            return await self._async_step_reconfigure_cheapest(entry, user_input)
 
         if user_input is not None:
             self._data.update(user_input)
@@ -696,6 +782,47 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return await self._show_reconfig_form(user_input)
         return await self._show_reconfig_form(user_input)
+
+    async def _async_step_reconfigure_cheapest(self, entry, user_input):
+        """Handle reconfigure for a cheapest gas tracker entry."""
+        if user_input is not None:
+            solver = (user_input.get(CONF_SOLVER) or "").strip() or None
+            if solver:
+                url_valid = await validate_url(solver)
+                if not url_valid:
+                    self._errors[CONF_SOLVER] = "invalid_url"
+                    return await self._show_reconfig_cheapest_form(user_input)
+
+            new_data: dict[str, Any] = {
+                **self._data,
+                CONF_NAME: user_input[CONF_NAME],
+                CONF_FUEL_KEY: user_input[CONF_FUEL_KEY],
+                CONF_PRICE_TYPE: user_input[CONF_PRICE_TYPE],
+                CONF_SOLVER: solver,
+                CONF_TIMEOUT: user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            }
+            postal = (user_input.get(CONF_POSTAL) or "").strip()
+            if postal:
+                new_data[CONF_POSTAL] = postal
+            else:
+                new_data.pop(CONF_POSTAL, None)
+
+            self.hass.config_entries.async_update_entry(
+                entry, title=new_data[CONF_NAME], data=new_data
+            )
+            self.hass.async_create_task(self.hass.config_entries.async_reload(entry.entry_id))
+            _LOGGER.debug("%s cheapest entry reconfigured.", DOMAIN)
+            return self.async_abort(reason="reconfigure_successful")
+
+        return await self._show_reconfig_cheapest_form(user_input)
+
+    async def _show_reconfig_cheapest_form(self, user_input):
+        """Show the cheapest reconfigure form pre-filled with current entry data."""
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_get_schema_cheapest(self.hass, user_input, self._data),
+            errors=self._errors,
+        )
 
     async def _show_reconfig_form(self, user_input):
         """Show the configuration form to edit configuration data."""

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -814,7 +814,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     options[CONF_EV_CHARGING] = False
                     options[CONF_FETCH_GAS] = True
 
-                self.hass.config_entries.async_update_entry(entry, data=self._data, options=options)
+                self.hass.config_entries.async_update_entry(
+                    entry, title=self._data[CONF_NAME], data=self._data, options=options
+                )
                 self.hass.async_create_task(self.hass.config_entries.async_reload(entry.entry_id))
                 _LOGGER.debug("%s reconfigured.", DOMAIN)
                 return self.async_abort(reason="reconfigure_successful")

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -727,7 +727,7 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             solver = (user_input.get(CONF_SOLVER) or "").strip() or None
             if solver:
-                url_valid = await validate_url(solver)
+                url_valid = validate_url(solver)
                 if not url_valid:
                     self._errors[CONF_SOLVER] = "invalid_url"
                     return await self._show_config_cheapest(user_input)
@@ -826,7 +826,7 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             solver = (user_input.get(CONF_SOLVER) or "").strip() or None
             if solver:
-                url_valid = await validate_url(solver)
+                url_valid = validate_url(solver)
                 if not url_valid:
                     self._errors[CONF_SOLVER] = "invalid_url"
                     return await self._show_reconfig_cheapest_form(user_input)

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -248,9 +248,9 @@ def _get_schema_manual(  # pylint: disable-next=unused-argument
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
-        vol.Optional(
-            CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
+        vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)): vol.All(
+            cv.positive_int, vol.Range(min=1000, max=300000)
+        ),
     })
 
 
@@ -271,9 +271,9 @@ def _get_schema_home(
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
-        vol.Optional(
-            CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
+        vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)): vol.All(
+            cv.positive_int, vol.Range(min=1000, max=300000)
+        ),
     })
 
 
@@ -317,9 +317,9 @@ def _get_schema_postal(  # pylint: disable-next=unused-argument
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
-        vol.Optional(
-            CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
+        vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)): vol.All(
+            cv.positive_int, vol.Range(min=1000, max=300000)
+        ),
     })
 
 
@@ -363,13 +363,17 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
         vol.Optional(CONF_POSTAL, default=_get_default(CONF_POSTAL, "")): vol.All(
             vol.Coerce(str), vol.Strip
         ),
-        vol.Required(CONF_FUEL_KEY, default=_get_default(CONF_FUEL_KEY, "regular_gas")): SelectSelector(
+        vol.Required(
+            CONF_FUEL_KEY, default=_get_default(CONF_FUEL_KEY, "regular_gas")
+        ): SelectSelector(
             SelectSelectorConfig(
                 options=[{"value": k, "label": v} for k, v in FUEL_KEY_CHOICES.items()],
                 mode=SelectSelectorMode.DROPDOWN,
             )
         ),
-        vol.Required(CONF_PRICE_TYPE, default=_get_default(CONF_PRICE_TYPE, "best")): SelectSelector(
+        vol.Required(
+            CONF_PRICE_TYPE, default=_get_default(CONF_PRICE_TYPE, "best")
+        ): SelectSelector(
             SelectSelectorConfig(
                 options=[{"value": k, "label": v} for k, v in PRICE_TYPE_CHOICES.items()],
                 mode=SelectSelectorMode.DROPDOWN,
@@ -378,9 +382,9 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
-        vol.Optional(
-            CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
+        vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)): vol.All(
+            cv.positive_int, vol.Range(min=1000, max=300000)
+        ),
     })
 
 

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -53,9 +53,9 @@ class SearchFailed(HomeAssistantError):
 
 
 def validate_url(url: str) -> bool:
-    """Validate user input URL."""
+    """Validate user input URL. Only http/https schemes are accepted."""
     pattern = re.compile(
-        r"^(?:http|ftp)s?://"
+        r"^https?://"
         r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"
         r"localhost|"
         r"[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?|"
@@ -151,7 +151,7 @@ async def _get_station_list(
 
     if user_input is not None and CONF_SOLVER in user_input and user_input[CONF_SOLVER]:
         solver = user_input[CONF_SOLVER]
-        _LOGGER.debug("Using solver URL: %s", solver)
+        _LOGGER.debug("Solver URL configured: %s", bool(solver))
 
     try:
         stations = await py_gasbuddy.GasBuddy(
@@ -163,7 +163,7 @@ async def _get_station_list(
         raise SearchFailed from ex
 
     stations_list = {}
-    _LOGGER.debug("search reply: %s", stations)
+    _LOGGER.debug("search reply: %s stations returned", len(stations.get("results", [])))
 
     for station in stations.get("results", []):
         full_name = f"{station['name']} @ {station['address']['line1']}"
@@ -203,12 +203,13 @@ async def _get_station_list(
                 ev_id = ev_station["station_id"]
                 full_name = f"{ev_station['name']} @ {ev_station.get('street_address') or ''} [EV]"
                 stations_list[ev_id] = full_name
-                # Cache coordinates
+                # Cache coordinates (bounded to 50 flow IDs)
                 hass.data.setdefault(DOMAIN, {})
-                hass.data[DOMAIN].setdefault("station_coordinates_by_flow", {})
-                flow_cache = hass.data[DOMAIN]["station_coordinates_by_flow"].setdefault(
-                    flow_id, {}
-                )
+                coord_cache = hass.data[DOMAIN].setdefault("station_coordinates_by_flow", {})
+                if len(coord_cache) >= 50:
+                    for old_key in list(coord_cache.keys())[:10]:
+                        coord_cache.pop(old_key, None)
+                flow_cache = coord_cache.setdefault(flow_id, {})
                 flow_cache[str(ev_id)] = (
                     ev_station.get("latitude"),
                     ev_station.get("longitude"),
@@ -236,17 +237,17 @@ def _get_schema_manual(  # pylint: disable-next=unused-argument
 
     return vol.Schema({
         vol.Required(CONF_STATION_ID, default=_get_default(CONF_STATION_ID)): vol.All(
-            cv.string, vol.Strip
+            cv.string, vol.Strip, vol.Match(r"^\d{1,20}$")
         ),
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
-            cv.string, vol.Strip
+            cv.string, vol.Strip, vol.Length(max=100)
         ),
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
         vol.Optional(
             CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): cv.positive_int,
+        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
     })
 
 
@@ -269,7 +270,7 @@ def _get_schema_home(
         ),
         vol.Optional(
             CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): cv.positive_int,
+        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
     })
 
 
@@ -290,7 +291,7 @@ def _get_schema_home2(
     return vol.Schema({
         vol.Required(CONF_STATION_ID, default=_get_default(CONF_STATION_ID)): vol.In(station_list),
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
-            cv.string, vol.Strip
+            cv.string, vol.Strip, vol.Length(max=100)
         ),
     })
 
@@ -308,14 +309,16 @@ def _get_schema_postal(  # pylint: disable-next=unused-argument
 
     return vol.Schema({
         vol.Required(CONF_POSTAL, default=_get_default(CONF_POSTAL)): vol.All(
-            vol.Coerce(str), vol.Strip
+            vol.Coerce(str),
+            vol.Strip,
+            vol.Match(r"^\d{5}(-\d{4})?$|^[A-Za-z]\d[A-Za-z] ?\d[A-Za-z]\d$"),
         ),
         vol.Optional(CONF_SOLVER, default=_get_default(CONF_SOLVER, "")): vol.All(
             cv.string, vol.Strip
         ),
         vol.Optional(
             CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): cv.positive_int,
+        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
     })
 
 
@@ -336,7 +339,7 @@ def _get_schema_station_list(
     return vol.Schema({
         vol.Required(CONF_STATION_ID, default=_get_default(CONF_STATION_ID)): vol.In(station_list),
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
-            cv.string, vol.Strip
+            cv.string, vol.Strip, vol.Length(max=100)
         ),
     })
 
@@ -354,7 +357,7 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
 
     return vol.Schema({
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, "Cheapest Gas")): vol.All(
-            cv.string, vol.Strip
+            cv.string, vol.Strip, vol.Length(max=100)
         ),
         vol.Optional(CONF_POSTAL, default=_get_default(CONF_POSTAL, "")): vol.All(
             vol.Coerce(str), vol.Strip
@@ -370,7 +373,7 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
         ),
         vol.Optional(
             CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        ): cv.positive_int,
+        ): vol.All(cv.positive_int, vol.Range(min=1000, max=300000)),
     })
 
 
@@ -556,6 +559,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 ev_charging = False
 
+            self.hass.data.get(DOMAIN, {}).get("station_coordinates_by_flow", {}).pop(
+                self.flow_id, None
+            )
             return self.async_create_entry(
                 title=self._data[CONF_NAME],
                 data=self._data,
@@ -657,6 +663,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 ev_charging = False
 
+            self.hass.data.get(DOMAIN, {}).get("station_coordinates_by_flow", {}).pop(
+                self.flow_id, None
+            )
             return self.async_create_entry(
                 title=self._data[CONF_NAME],
                 data=self._data,

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -19,6 +19,9 @@ CONF_SOLVER = "solver"
 CONF_TIMEOUT = "timeout"
 CONF_EV_CHARGING = "ev_charging"
 CONF_FETCH_GAS = "fetch_gas"
+CONF_CHEAPEST = "cheapest"
+CONF_FUEL_KEY = "fuel_key"
+CONF_PRICE_TYPE = "price_type"
 DEFAULT_INTERVAL = 3600
 DEFAULT_NAME = "Gas Station"
 DEFAULT_TIMEOUT = 60000
@@ -49,6 +52,22 @@ SERVICE_CLEAR_CACHE = "clear_cache"
 UNIT_OF_MEASURE = {
     "dollars_per_gallon": "gallon",
     "cents_per_liter": "liter",
+}
+
+FUEL_KEY_CHOICES = {
+    "regular_gas": "Regular",
+    "midgrade_gas": "Midgrade",
+    "premium_gas": "Premium",
+    "diesel": "Diesel",
+    "e85": "E85",
+    "e15": "UNL88",
+}
+
+PRICE_TYPE_CHOICES = {
+    "best": "Best (deal → cash → credit)",
+    "credit": "Credit",
+    "cash": "Cash",
+    "deal": "Deal/GasBuddy Pay",
 }
 
 
@@ -159,6 +178,76 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    # Deal price sensors
+    "regular_gas_deal": GasBuddySensorEntityDescription(
+        key="regular_gas",
+        name="Regular Gas (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "midgrade_gas_deal": GasBuddySensorEntityDescription(
+        key="midgrade_gas",
+        name="MidGrade Gas (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "premium_gas_deal": GasBuddySensorEntityDescription(
+        key="premium_gas",
+        name="Premium Gas (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "diesel_deal": GasBuddySensorEntityDescription(
+        key="diesel",
+        name="Diesel (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "e85_deal": GasBuddySensorEntityDescription(
+        key="e85",
+        name="E85 (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "e15_deal": GasBuddySensorEntityDescription(
+        key="e15",
+        name="UNL88 (Deal)",
+        deal=True,
+        icon="mdi:gas-station",
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    # Station info sensors
+    "open_status": GasBuddySensorEntityDescription(
+        key="open_status",
+        name="Station Status",
+        icon="mdi:door-open",
+        price=False,
+        entity_registry_enabled_default=False,
+    ),
+    "station_name": GasBuddySensorEntityDescription(
+        key="name",
+        name="Station Name",
+        icon="mdi:gas-station",
+        price=False,
+        entity_registry_enabled_default=False,
     ),
     # EV Charging Sensors
     "ev_level1": GasBuddySensorEntityDescription(

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -64,7 +64,7 @@ FUEL_KEY_CHOICES = {
 }
 
 PRICE_TYPE_CHOICES = {
-    "best": "Best (deal → cash → credit)",
+    "best": "Best (lowest available price)",
     "credit": "Credit",
     "cash": "Cash",
     "deal": "Deal/GasBuddy Pay",

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -172,6 +172,7 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
             else:
                 raise UpdateFailed(f"Error retrieving data: {ex}") from ex
         except Exception as exception:
+            _LOGGER.warning("Unexpected error updating gasbuddy: %s", exception, exc_info=True)
             raise UpdateFailed from exception
 
         # Query EV station details if enabled

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -16,9 +16,13 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_CHEAPEST,
     CONF_EV_CHARGING,
+    CONF_FUEL_KEY,
     CONF_INTERVAL,
     CONF_NAME,
+    CONF_POSTAL,
+    CONF_PRICE_TYPE,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -69,7 +73,7 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         self._cache_file = f"{self.hass.config.config_dir}/.storage/gasbuddy_cache"
         self._api = GasBuddy(
             solver_url=config.data.get(CONF_SOLVER),
-            station_id=config.data[CONF_STATION_ID],
+            station_id=config.data.get(CONF_STATION_ID),
             cache_file=self._cache_file,
             timeout=config.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             session=async_get_clientsession(hass),
@@ -87,6 +91,9 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict:
         """Update data via library."""
+        if self._config.data.get(CONF_CHEAPEST):
+            return await self._async_update_cheapest()
+
         ev_charging_enabled = self._config.options.get(CONF_EV_CHARGING, False)
         try:
             self._data = await self._api.price_lookup()
@@ -233,6 +240,53 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         self._data["last_updated"] = datetime.now(UTC)
         _LOGGER.debug("Final coordinator data: %s", _redact(self._data))
         return self._data
+
+    async def _async_update_cheapest(self) -> dict:
+        """Find and return the cheapest nearby station for the configured fuel and price type."""
+        fuel_key = self._config.data.get(CONF_FUEL_KEY, "regular_gas")
+        price_type = self._config.data.get(CONF_PRICE_TYPE, "best")
+
+        postal = self._config.data.get(CONF_POSTAL)
+        lat: float | None = None
+        lon: float | None = None
+        if not postal:
+            lat = self._config.data.get("latitude") or self.hass.config.latitude
+            lon = self._config.data.get("longitude") or self.hass.config.longitude
+
+        try:
+            result = await self._api.price_lookup_service(
+                lat=lat,
+                lon=lon,
+                zipcode=postal,
+                limit=20,
+            )
+        except (APIError, LibraryError, CSRFTokenMissing) as ex:
+            raise UpdateFailed(f"Cheapest gas lookup failed: {ex}") from ex
+
+        stations = [s for s in (result.get("results") or []) if s.get(fuel_key)]
+        if not stations:
+            raise UpdateFailed("No stations with prices found for selected fuel")
+
+        def _sort_key(s: dict) -> float:
+            node = s.get(fuel_key) or {}
+            if price_type == "best":
+                candidates = [node.get("deal_price"), node.get("cash_price"), node.get("price")]
+                vals = [p for p in candidates if p is not None]
+                return min(vals) if vals else float("inf")
+            if price_type == "deal":
+                return (
+                    node.get("deal_price")
+                    or node.get("cash_price")
+                    or node.get("price")
+                    or float("inf")
+                )
+            field = "cash_price" if price_type == "cash" else "price"
+            return node.get(field) or float("inf")
+
+        cheapest = min(stations, key=_sort_key)
+        cheapest["last_updated"] = datetime.now(UTC)
+        _LOGGER.debug("Cheapest gas station: %s", _redact(cheapest))
+        return cheapest
 
     async def clear_cache(self) -> None:
         """Clear cache file."""

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -3,6 +3,8 @@
 from datetime import UTC, datetime, timedelta
 import json
 import logging
+import math
+import operator
 from typing import Any
 
 from py_gasbuddy import GasBuddy
@@ -284,7 +286,13 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
             field = "cash_price" if price_type == "cash" else "price"
             return node.get(field) or float("inf")
 
-        cheapest = min(stations, key=_sort_key)
+        keyed = [(s, _sort_key(s)) for s in stations]
+        finite = [(s, k) for s, k in keyed if math.isfinite(k)]
+        if not finite:
+            raise UpdateFailed(
+                "No stations with a valid price found for selected fuel and price type"
+            )
+        cheapest = min(finite, key=operator.itemgetter(1))[0]
         cheapest["last_updated"] = datetime.now(UTC)
         _LOGGER.debug("Cheapest gas station: %s", _redact(cheapest))
         return cheapest

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -253,8 +253,10 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         lat: float | None = None
         lon: float | None = None
         if not postal:
-            lat = self._config.data.get("latitude") or self.hass.config.latitude
-            lon = self._config.data.get("longitude") or self.hass.config.longitude
+            config_lat = self._config.data.get("latitude")
+            lat = config_lat if config_lat is not None else self.hass.config.latitude
+            config_lon = self._config.data.get("longitude")
+            lon = config_lon if config_lon is not None else self.hass.config.longitude
 
         try:
             result = await self._api.price_lookup_service(
@@ -277,14 +279,11 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                 vals = [p for p in candidates if p is not None]
                 return min(vals) if vals else float("inf")
             if price_type == "deal":
-                return (
-                    node.get("deal_price")
-                    or node.get("cash_price")
-                    or node.get("price")
-                    or float("inf")
-                )
+                dp = node.get("deal_price")
+                return dp if dp is not None else float("inf")
             field = "cash_price" if price_type == "cash" else "price"
-            return node.get(field) or float("inf")
+            v = node.get(field)
+            return v if v is not None else float("inf")
 
         keyed = [(s, _sort_key(s)) for s in stations]
         finite = [(s, k) for s, k in keyed if math.isfinite(k)]

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -45,6 +45,7 @@ def _redact(data: Any) -> str:
         "city",
         "state",
         "zip",
+        "station_id",
     }
 
     def _redact_recursive(obj: Any) -> Any:

--- a/custom_components/gasbuddy/diagnostics.py
+++ b/custom_components/gasbuddy/diagnostics.py
@@ -6,13 +6,24 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import COORDINATOR, DOMAIN
+from .const import CONF_POSTAL, CONF_SOLVER, COORDINATOR, DOMAIN
 
-REDACT_KEYS = {CONF_PASSWORD}
+REDACT_KEYS = {
+    CONF_SOLVER,
+    CONF_POSTAL,
+    "latitude",
+    "longitude",
+    "street_address",
+    "ev_station_address",
+    "city",
+    "state",
+    "zip",
+    "phone",
+    "address",
+}
 
 
 async def async_get_config_entry_diagnostics(  # pylint: disable-next=unused-argument
@@ -29,4 +40,4 @@ async def async_get_device_diagnostics(  # pylint: disable-next=unused-argument
 ) -> dict[str, Any]:
     """Return diagnostics for a device."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
-    return coordinator.data
+    return async_redact_data(coordinator.data or {}, REDACT_KEYS)

--- a/custom_components/gasbuddy/diagnostics.py
+++ b/custom_components/gasbuddy/diagnostics.py
@@ -23,6 +23,12 @@ REDACT_KEYS = {
     "zip",
     "phone",
     "address",
+    "station_id",
+    "id",
+    "station_code",
+    "station_identifier",
+    "station_number",
+    "uid",
 }
 
 

--- a/custom_components/gasbuddy/entity.py
+++ b/custom_components/gasbuddy/entity.py
@@ -12,4 +12,5 @@ class GasBuddySensorEntityDescription(SensorEntityDescription):
     """Class describing OpenEVSE select entities."""
 
     cash: bool | None = None
+    deal: bool | None = None
     price: bool | None = True

--- a/custom_components/gasbuddy/manifest.json
+++ b/custom_components/gasbuddy/manifest.json
@@ -13,7 +13,7 @@
     "gasbuddy"
   ],
   "requirements": [
-    "py_gasbuddy==0.5.1"
+    "py_gasbuddy==0.6.0"
   ],
   "version": "0.0.0-dev"
 }

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import Any
 
@@ -22,6 +23,7 @@ from .const import (
     CONF_UOM,
     COORDINATOR,
     DOMAIN,
+    FUEL_KEY_CHOICES,
     SENSOR_TYPES,
     UNIT_OF_MEASURE,
 )
@@ -37,13 +39,43 @@ async def async_setup_entry(hass, entry, async_add_entities):
     ev_charging = entry.options.get(CONF_EV_CHARGING, False)
     fetch_gas = entry.options.get(CONF_FETCH_GAS, True)
 
+    data = coordinator.data or {}
+    fuels_available: set[str] = set()
+    for fk in FUEL_KEY_CHOICES:
+        if fk in data:
+            fuels_available.add(fk)
+    if isinstance(data.get("fuels"), list):
+        fuels_available.update(data["fuels"])
+
     sensors = []
-    for sensor_type in SENSOR_TYPES:
+    for sensor_type, description in SENSOR_TYPES.items():
         if sensor_type.startswith("ev_") and not ev_charging:
             continue
-        if not sensor_type.startswith("ev_") and sensor_type != "last_updated" and not fetch_gas:
+        if (
+            not sensor_type.startswith("ev_")
+            and sensor_type not in {"last_updated", "open_status", "station_name"}
+            and not fetch_gas
+        ):
             continue
-        sensors.append(GasBuddySensor(SENSOR_TYPES[sensor_type], coordinator, entry))
+
+        enabled = description.entity_registry_enabled_default
+        fuel_key = description.key
+
+        if fuel_key in FUEL_KEY_CHOICES and data:
+            if description.deal:
+                enabled = fuel_key in fuels_available and bool(
+                    (data.get(fuel_key) or {}).get("deal_price")
+                )
+            elif description.cash:
+                enabled = (
+                    fuel_key in fuels_available
+                    and (data.get(fuel_key) or {}).get("cash_price") is not None
+                )
+            else:
+                enabled = fuel_key in fuels_available
+
+        mod_desc = dataclasses.replace(description, entity_registry_enabled_default=enabled)
+        sensors.append(GasBuddySensor(mod_desc, coordinator, entry))
 
     async_add_entities(sensors, False)
 
@@ -68,6 +100,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
         self.coordinator = coordinator
         self._state = None
         self._cash = sensor_description.cash
+        self._deal = sensor_description.deal
         self._price = sensor_description.price
 
         self._attr_icon = sensor_description.icon
@@ -102,7 +135,9 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
                 return val.lower()
             return val
 
-        if self._cash:
+        if self._deal:
+            price = data[self._type].get("deal_price")
+        elif self._cash:
             price = data[self._type].get("cash_price")
         else:
             price = data[self._type].get("price")
@@ -143,7 +178,9 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
         attrs: dict[str, Any] = {}
 
         if not self._price:
-            if not self._type.startswith("ev_"):
+            if not self._type.startswith("ev_") and self._type not in {"open_status", "name"}:
+                return None
+            if self._type in {"open_status", "name"}:
                 return None
             attrs[CONF_STATION_ID] = data.get(CONF_STATION_ID)
             attrs["station_name"] = data.get("ev_station_name")
@@ -171,6 +208,22 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         attrs["last_updated"] = data[self._type].get("last_updated")
         attrs[CONF_STATION_ID] = data.get(CONF_STATION_ID)
+
+        if fp := data[self._type].get("formatted_price"):
+            attrs["formatted_price"] = fp
+        if dp := data[self._type].get("deal_price"):
+            attrs["deal_price"] = dp
+        if phone := data.get("phone"):
+            attrs["phone"] = phone
+        if rating := data.get("star_rating"):
+            attrs["star_rating"] = rating
+        if addr := data.get("address"):
+            attrs["address"] = (
+                f"{addr.get('line1', '')}, {addr.get('locality', '')}, {addr.get('region', '')}"
+            )
+        if amenities := data.get("amenities"):
+            attrs["amenities"] = ", ".join(a["name"] for a in amenities if a.get("name"))
+
         if self._config.options.get(CONF_GPS):
             attrs[ATTR_LATITUDE] = data.get(ATTR_LATITUDE)
             attrs[ATTR_LONGITUDE] = data.get(ATTR_LONGITUDE)
@@ -194,7 +247,10 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
             return False
 
         if self._price:
-            if self._cash:
+            if self._deal:
+                if data[self._type].get("deal_price") is None:
+                    return False
+            elif self._cash:
                 if data[self._type].get("cash_price") is None:
                     return False
             elif data[self._type].get("price") is None:

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -63,8 +63,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
         if fuel_key in FUEL_KEY_CHOICES and data:
             if description.deal:
-                enabled = fuel_key in fuels_available and bool(
-                    (data.get(fuel_key) or {}).get("deal_price")
+                enabled = (
+                    fuel_key in fuels_available
+                    and bool(data.get("pay_status"))
+                    and bool((data.get(fuel_key) or {}).get("deal_price"))
                 )
             elif description.cash:
                 enabled = (
@@ -211,7 +213,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         if fp := data[self._type].get("formatted_price"):
             attrs["formatted_price"] = fp
-        if dp := data[self._type].get("deal_price"):
+        if data.get("pay_status") and (dp := data[self._type].get("deal_price")):
             attrs["deal_price"] = dp
         if phone := data.get("phone"):
             attrs["phone"] = phone
@@ -248,7 +250,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         if self._price:
             if self._deal:
-                if data[self._type].get("deal_price") is None:
+                if not data.get("pay_status") or data[self._type].get("deal_price") is None:
                     return False
             elif self._cash:
                 if data[self._type].get("cash_price") is None:

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -66,7 +66,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 enabled = (
                     fuel_key in fuels_available
                     and bool(data.get("pay_status"))
-                    and bool((data.get(fuel_key) or {}).get("deal_price"))
+                    and (data.get(fuel_key) or {}).get("deal_price") is not None
                 )
             elif description.cash:
                 enabled = (
@@ -213,7 +213,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         if fp := data[self._type].get("formatted_price"):
             attrs["formatted_price"] = fp
-        if data.get("pay_status") and (dp := data[self._type].get("deal_price")):
+        if data.get("pay_status") and (dp := data[self._type].get("deal_price")) is not None:
             attrs["deal_price"] = dp
         if phone := data.get("phone"):
             attrs["phone"] = phone

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -65,7 +65,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             if description.deal:
                 enabled = (
                     fuel_key in fuels_available
-                    and bool(data.get("pay_status"))
                     and (data.get(fuel_key) or {}).get("deal_price") is not None
                 )
             elif description.cash:
@@ -213,7 +212,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         if fp := data[self._type].get("formatted_price"):
             attrs["formatted_price"] = fp
-        if data.get("pay_status") and (dp := data[self._type].get("deal_price")) is not None:
+        if (dp := data[self._type].get("deal_price")) is not None:
             attrs["deal_price"] = dp
         if phone := data.get("phone"):
             attrs["phone"] = phone
@@ -250,7 +249,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
 
         if self._price:
             if self._deal:
-                if not data.get("pay_status") or data[self._type].get("deal_price") is None:
+                if data[self._type].get("deal_price") is None:
                     return False
             elif self._cash:
                 if data[self._type].get("cash_price") is None:

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -144,7 +144,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
         else:
             price = data[self._type].get("price")
 
-        if not price:
+        if price is None:
             return None
 
         if data.get("unit_of_measure") == "cents_per_liter":

--- a/custom_components/gasbuddy/services.py
+++ b/custom_components/gasbuddy/services.py
@@ -1,6 +1,7 @@
 """GasBuddy services."""
 
 import logging
+import re
 
 from py_gasbuddy import GasBuddy
 from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, LibraryError
@@ -15,6 +16,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -32,6 +34,24 @@ from .const import (
     SERVICE_LOOKUP_GPS,
     SERVICE_LOOKUP_ZIP,
 )
+
+_SOLVER_URL_RE = re.compile(
+    r"^https?://"
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"
+    r"localhost|"
+    r"[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?|"
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
+    r"(?::\d+)?"
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+
+def _require_valid_solver(solver: str | None) -> None:
+    """Raise ServiceValidationError if solver URL is present but invalid."""
+    if solver and not _SOLVER_URL_RE.match(solver):
+        raise ServiceValidationError("Invalid FlareSolverr URL")
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -129,6 +149,7 @@ class GasBuddyServices:
         if ATTR_SOLVER in service.data:
             solver = service.data[ATTR_SOLVER]
 
+        _require_valid_solver(solver)
         results = {}
         api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
         for entity_id in entity_ids:
@@ -158,6 +179,7 @@ class GasBuddyServices:
         if ATTR_SOLVER in service.data:
             solver = service.data[ATTR_SOLVER]
 
+        _require_valid_solver(solver)
         results = {}
         try:
             results = await GasBuddy(
@@ -185,6 +207,7 @@ class GasBuddyServices:
         if ATTR_SOLVER in service.data:
             solver = service.data[ATTR_SOLVER]
 
+        _require_valid_solver(solver)
         results = {}
         api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
         for entity_id in entity_ids:
@@ -227,6 +250,7 @@ class GasBuddyServices:
         if ATTR_SOLVER in service.data:
             solver = service.data[ATTR_SOLVER]
 
+        _require_valid_solver(solver)
         results = {}
         api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
         try:
@@ -266,7 +290,9 @@ class GasBuddyServices:
             if not device_entry:
                 raise ValueError(f"Device ID {device_id} is not valid")
 
-            config_id = list(device_entry.connections)[0][1]
+            config_id = next(iter(device_entry.config_entries), None)
+            if not config_id:
+                raise ValueError(f"No config entry found for device {device_id}")
             _LOGGER.debug("Config ID: %s", config_id)
             manager = self.hass.data[DOMAIN][config_id][COORDINATOR]
             await manager.clear_cache()

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -13,7 +13,8 @@
                 "description": "Please select either manual station ID or search for a station.",
                 "menu_options": {
                     "manual": "Enter Station ID Manually",
-                    "search": "Search for a station nearby"
+                    "search": "Search for a station nearby",
+                    "cheapest": "Track cheapest nearby gas"
                 }
             },
             "manual": {
@@ -53,13 +54,27 @@
                     "station_id": "Station"
                 }
             },
+            "cheapest": {
+                "description": "Track the cheapest nearby gas station. Uses your home coordinates or a postal code. On every refresh the coordinator re-checks and updates to the current cheapest station.",
+                "data": {
+                    "name": "Name",
+                    "zipcode": "Postal Code (optional — leave blank to use HA home coordinates)",
+                    "fuel_key": "Fuel type",
+                    "price_type": "Price type",
+                    "solver": "FlareSolverr URL (optional)",
+                    "timeout": "FlareSolverr timeout (ms)"
+                }
+            },
             "reconfigure": {
                 "description": "Please enter the Station ID",
                 "data": {
                     "solver": "FlareSolverr URL (optional)",
                     "timeout": "FlareSolverr timeout (ms)",
                     "station_id": "Station ID",
-                    "name": "Name"
+                    "name": "Name",
+                    "zipcode": "Postal Code (optional — leave blank to use HA home coordinates)",
+                    "fuel_key": "Fuel type",
+                    "price_type": "Price type"
                 }
             }
         }

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -66,7 +66,7 @@
                 }
             },
             "reconfigure": {
-                "description": "Please enter the Station ID",
+                "description": "Please enter the configuration details for this entry",
                 "data": {
                     "solver": "FlareSolverr URL (optional)",
                     "timeout": "FlareSolverr timeout (ms)",

--- a/custom_components/gasbuddy/translations/en.json
+++ b/custom_components/gasbuddy/translations/en.json
@@ -13,7 +13,8 @@
                 "description": "Please select either manual station ID or search for a station.",
                 "menu_options": {
                     "manual": "Enter Station ID Manually",
-                    "search": "Search for a station nearby"
+                    "search": "Search for a station nearby",
+                    "cheapest": "Track cheapest nearby gas"
                 }
             },
             "manual": {
@@ -53,13 +54,27 @@
                     "station_id": "Station"
                 }
             },
+            "cheapest": {
+                "description": "Track the cheapest nearby gas station. Uses your home coordinates or a postal code. On every refresh the coordinator re-checks and updates to the current cheapest station.",
+                "data": {
+                    "name": "Name",
+                    "zipcode": "Postal Code (optional — leave blank to use HA home coordinates)",
+                    "fuel_key": "Fuel type",
+                    "price_type": "Price type",
+                    "solver": "FlareSolverr URL (optional)",
+                    "timeout": "FlareSolverr timeout (ms)"
+                }
+            },
             "reconfigure": {
                 "description": "Please enter the Station ID",
                 "data": {
                     "solver": "FlareSolverr URL (optional)",
                     "timeout": "FlareSolverr timeout (ms)",
                     "station_id": "Station ID",
-                    "name": "Name"
+                    "name": "Name",
+                    "zipcode": "Postal Code (optional — leave blank to use HA home coordinates)",
+                    "fuel_key": "Fuel type",
+                    "price_type": "Price type"
                 }
             }
         }

--- a/custom_components/gasbuddy/translations/es.json
+++ b/custom_components/gasbuddy/translations/es.json
@@ -1,0 +1,106 @@
+{
+    "config": {
+        "abort": {
+            "reconfigure_successful": "Reconfiguración exitosa"
+        },
+        "error": {
+            "station_id": "ID de estación inválido",
+            "no_results": "No se encontraron estaciones en esta área.",
+            "invalid_url": "URL no válida."
+        },
+        "step": {
+            "user": {
+                "description": "Por favor, seleccione un ID de estación manualmente o busque una estación.",
+                "menu_options": {
+                    "manual": "Ingresar ID de estación manualmente",
+                    "search": "Buscar una estación cercana",
+                    "cheapest": "Rastrear el combustible más barato cercano"
+                }
+            },
+            "manual": {
+                "description": "Por favor, ingrese el ID de la estación",
+                "data": {
+                    "solver": "URL de FlareSolverr (opcional)",
+                    "timeout": "Tiempo de espera de FlareSolverr (ms)",
+                    "station_id": "ID de Estación"
+                }
+            },
+            "search": {
+                "description": "Buscar por su ubicación GPS configurada o por código postal",
+                "menu_options": {
+                    "home": "Usar coordenadas configuradas en Home Assistant",
+                    "postal": "Usar código postal"
+                }
+            },
+            "home": {
+                "description": "Por favor, seleccione una estación",
+                "data": {
+                    "solver": "URL de FlareSolverr (opcional)",
+                    "timeout": "Tiempo de espera de FlareSolverr (ms)",
+                    "station_id": "Estación"
+                }
+            },
+            "postal": {
+                "description": "Por favor, ingrese un código postal",
+                "data": {
+                    "solver": "URL de FlareSolverr (opcional)",
+                    "timeout": "Tiempo de espera de FlareSolverr (ms)",
+                    "zipcode": "Código Postal"
+                }
+            },
+            "station_list": {
+                "description": "Por favor, seleccione una estación",
+                "data": {
+                    "station_id": "Estación"
+                }
+            },
+            "cheapest": {
+                "description": "Rastree la estación de servicio más barata cercana. Usa las coordenadas de su hogar o un código postal. En cada actualización, el coordinador vuelve a evaluar y actualiza a la estación más barata en ese momento.",
+                "data": {
+                    "name": "Nombre",
+                    "zipcode": "Código Postal (opcional — dejar en blanco para usar las coordenadas de HA)",
+                    "fuel_key": "Tipo de combustible",
+                    "price_type": "Tipo de precio",
+                    "solver": "URL de FlareSolverr (opcional)",
+                    "timeout": "Tiempo de espera de FlareSolverr (ms)"
+                }
+            },
+            "reconfigure": {
+                "description": "Por favor, ingrese el ID de la estación",
+                "data": {
+                    "solver": "URL de FlareSolverr (opcional)",
+                    "timeout": "Tiempo de espera de FlareSolverr (ms)",
+                    "station_id": "ID de Estación",
+                    "name": "Nombre",
+                    "zipcode": "Código Postal (opcional — dejar en blanco para usar las coordenadas de HA)",
+                    "fuel_key": "Tipo de combustible",
+                    "price_type": "Tipo de precio"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "interval": "Intervalo de actualización",
+                    "uom": "Mostrar por litro/galón en unidad de medida",
+                    "gps": "Mostrar estaciones en el mapa (deshabilitar atributos lat/long)",
+                    "ev_charging": "Habilitar sensores de carga de VE",
+                    "fetch_gas": "Obtener precios de combustible"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "ev_access": {
+                "state": {
+                    "public": "Público",
+                    "private": "Privado",
+                    "none": "Ninguno"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -1,25 +1,26 @@
 {
     "config": {
         "abort": {
-            "reconfigure_successful": "Reconfigure Successful"
+            "reconfigure_successful": "Reconfiguration réussie"
         },
         "error": {
             "station_id": "ID de station invalide",
-            "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "no_results": "Aucune station trouvée dans cette zone.",
+            "invalid_url": "URL non valide."
         },
         "step": {
             "user": {
                 "description": "Veuillez sélectionner soit l'ID de station manuel, soit rechercher une station.",
                 "menu_options": {
                     "manual": "Saisir manuellement l'ID de la station",
-                    "search": "Rechercher une station à proximité"
+                    "search": "Rechercher une station à proximité",
+                    "cheapest": "Suivre le carburant le moins cher à proximité"
                 }
             },
             "manual": {
                 "description": "Veuillez saisir l'ID de la station",
                 "data": {
-                    "solver": "FlareSolverr URL (optionnel)",
+                    "solver": "URL FlareSolverr (optionnel)",
                     "timeout": "Délai d'attente FlareSolverr (ms)",
                     "station_id": "Identifiant de la station"
                 }
@@ -28,38 +29,52 @@
                 "description": "Recherchez par votre position GPS configurée ou par code postal",
                 "menu_options": {
                     "home": "Utiliser les coordonnées configurées par Home Assistant",
-                    "postal": "Utiliser le code postal (code postal)"
+                    "postal": "Utiliser le code postal"
                 }
             },
             "home": {
                 "description": "Veuillez sélectionner une station",
                 "data": {
-                    "solver": "FlareSolverr URL (optionnel)",
+                    "solver": "URL FlareSolverr (optionnel)",
                     "timeout": "Délai d'attente FlareSolverr (ms)",
-                    "station_id": "Identifiant de la station"
+                    "station_id": "Station"
                 }
             },
             "postal": {
-                "description": "Veuillez entrer un code postal (code postal)",
+                "description": "Veuillez entrer un code postal",
                 "data": {
-                    "solver": "FlareSolverr URL (optionnel)",
+                    "solver": "URL FlareSolverr (optionnel)",
                     "timeout": "Délai d'attente FlareSolverr (ms)",
-                    "zipcode": "Code postal (code postal)"
+                    "zipcode": "Code postal"
                 }
             },
             "station_list": {
                 "description": "Veuillez sélectionner une station",
                 "data": {
-                    "station_id": "Identifiant de la station"
+                    "station_id": "Station"
+                }
+            },
+            "cheapest": {
+                "description": "Suivez la station-service la moins chère à proximité. Utilise vos coordonnées domicile ou un code postal. À chaque actualisation, le coordinateur réévalue et met à jour la station la moins chère du moment.",
+                "data": {
+                    "name": "Nom",
+                    "zipcode": "Code postal (optionnel — laisser vide pour utiliser les coordonnées HA)",
+                    "fuel_key": "Type de carburant",
+                    "price_type": "Type de prix",
+                    "solver": "URL FlareSolverr (optionnel)",
+                    "timeout": "Délai d'attente FlareSolverr (ms)"
                 }
             },
             "reconfigure": {
-                "description": "Please enter the Station ID",
+                "description": "Veuillez entrer l'identifiant de la station",
                 "data": {
-                    "solver": "FlareSolverr URL (optionnel)",
+                    "solver": "URL FlareSolverr (optionnel)",
                     "timeout": "Délai d'attente FlareSolverr (ms)",
-                    "station_id": "Station ID",
-                    "name": "Name"
+                    "station_id": "Identifiant de la station",
+                    "name": "Nom",
+                    "zipcode": "Code postal (optionnel — laisser vide pour utiliser les coordonnées HA)",
+                    "fuel_key": "Type de carburant",
+                    "price_type": "Type de prix"
                 }
             }
         }

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -66,7 +66,7 @@
                 }
             },
             "reconfigure": {
-                "description": "Por favor, insira o ID da estação",
+                "description": "Por favor, preencha os detalhes de configuração desta entrada",
                 "data": {
                     "solver": "URL do FlareSolverr (opcional)",
                     "timeout": "Tempo limite do FlareSolverr (ms)",

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -1,25 +1,26 @@
 {
     "config": {
         "abort": {
-            "reconfigure_successful": "Reconfigure Successful"
+            "reconfigure_successful": "Reconfiguração bem-sucedida"
         },
         "error": {
             "station_id": "ID de estação inválido",
-            "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "no_results": "Nenhuma estação encontrada nesta área.",
+            "invalid_url": "URL inválida."
         },
         "step": {
             "user": {
                 "description": "Por favor, selecione manualmente o ID da estação ou pesquise por uma estação.",
                 "menu_options": {
                     "manual": "Inserir ID da estação manualmente",
-                    "search": "Pesquisar por uma estação próxima"
+                    "search": "Pesquisar por uma estação próxima",
+                    "cheapest": "Rastrear o combustível mais barato próximo"
                 }
             },
             "manual": {
                 "description": "Por favor, insira o ID da estação",
                 "data": {
-                    "solver": "FlareSolverr URL (opcional)",
+                    "solver": "URL do FlareSolverr (opcional)",
                     "timeout": "Tempo limite do FlareSolverr (ms)",
                     "station_id": "ID da Estação"
                 }
@@ -34,7 +35,7 @@
             "home": {
                 "description": "Por favor, selecione uma estação",
                 "data": {
-                    "solver": "FlareSolverr URL (opcional)",
+                    "solver": "URL do FlareSolverr (opcional)",
                     "timeout": "Tempo limite do FlareSolverr (ms)",
                     "station_id": "Estação"
                 }
@@ -42,7 +43,7 @@
             "postal": {
                 "description": "Por favor, insira um código postal (CEP)",
                 "data": {
-                    "solver": "FlareSolverr URL (opcional)",
+                    "solver": "URL do FlareSolverr (opcional)",
                     "timeout": "Tempo limite do FlareSolverr (ms)",
                     "zipcode": "Código Postal (CEP)"
                 }
@@ -53,13 +54,27 @@
                     "station_id": "Estação"
                 }
             },
-            "reconfigure": {
-                "description": "Please enter the Station ID",
+            "cheapest": {
+                "description": "Rastreie a posto de combustível mais barata próxima. Usa suas coordenadas de casa ou um código postal. A cada atualização, o coordenador reavalia e atualiza para a estação mais barata no momento.",
                 "data": {
-                    "solver": "FlareSolverr URL (opcional)",
+                    "name": "Nome",
+                    "zipcode": "Código Postal (opcional — deixe em branco para usar as coordenadas do HA)",
+                    "fuel_key": "Tipo de combustível",
+                    "price_type": "Tipo de preço",
+                    "solver": "URL do FlareSolverr (opcional)",
+                    "timeout": "Tempo limite do FlareSolverr (ms)"
+                }
+            },
+            "reconfigure": {
+                "description": "Por favor, insira o ID da estação",
+                "data": {
+                    "solver": "URL do FlareSolverr (opcional)",
                     "timeout": "Tempo limite do FlareSolverr (ms)",
-                    "station_id": "Station ID",
-                    "name": "Name"
+                    "station_id": "ID da Estação",
+                    "name": "Nome",
+                    "zipcode": "Código Postal (opcional — deixe em branco para usar as coordenadas do HA)",
+                    "fuel_key": "Tipo de combustível",
+                    "price_type": "Tipo de preço"
                 }
             }
         }

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -55,7 +55,7 @@
                 }
             },
             "cheapest": {
-                "description": "Rastreie a posto de combustível mais barata próxima. Usa suas coordenadas de casa ou um código postal. A cada atualização, o coordenador reavalia e atualiza para a estação mais barata no momento.",
+                "description": "Rastreie o posto de combustível mais barato próximo. Usa suas coordenadas de casa ou um código postal. A cada atualização, o coordenador reavalia e atualiza para a estação mais barata no momento.",
                 "data": {
                     "name": "Nome",
                     "zipcode": "Código Postal (opcional — deixe em branco para usar as coordenadas do HA)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,6 +490,7 @@ ignore = [
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
   "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLW0717", # Try clause contains too many statements
   "PLR0917", # Too many positional arguments ({args} > {max_args})
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW1641", # __eq__ without __hash__

--- a/tests/const.py
+++ b/tests/const.py
@@ -72,6 +72,7 @@ STATION_LIST = {
 COORDINATOR_DATA = {
     "station_id": "208656",
     "name": "Costco",
+    "pay_status": True,
     "image_url": "https://images.gasbuddy.io/b/122.png",
     "unit_of_measure": "dollars_per_gallon",
     "currency": "USD",
@@ -147,6 +148,7 @@ OPTIONS_CHEAPEST = {
 COORDINATOR_DATA_CHEAPEST = {
     "station_id": "187725",
     "name": "Shell",
+    "pay_status": True,
     "image_url": None,
     "unit_of_measure": "dollars_per_gallon",
     "currency": "USD",

--- a/tests/const.py
+++ b/tests/const.py
@@ -3,9 +3,14 @@
 from datetime import UTC, datetime
 
 from custom_components.gasbuddy.const import (
+    CONF_CHEAPEST,
+    CONF_EV_CHARGING,
+    CONF_FETCH_GAS,
+    CONF_FUEL_KEY,
     CONF_GPS,
     CONF_INTERVAL,
     CONF_NAME,
+    CONF_PRICE_TYPE,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -66,34 +71,95 @@ STATION_LIST = {
 
 COORDINATOR_DATA = {
     "station_id": "208656",
+    "name": "Costco",
     "image_url": "https://images.gasbuddy.io/b/122.png",
     "unit_of_measure": "dollars_per_gallon",
     "currency": "USD",
     "gps": True,
     "latitude": 33.459108,
     "longitude": -112.502745,
+    "open_status": "open",
+    "phone": "555-555-5555",
+    "star_rating": 4.2,
+    "address": {
+        "line1": "1101 N Verrado Way",
+        "locality": "Buckeye",
+        "region": "AZ",
+        "postalCode": "85396",
+        "country": "US",
+    },
+    "amenities": [
+        {"amenityId": 1, "name": "ATM"},
+        {"amenityId": 2, "name": "Restrooms"},
+    ],
     "regular_gas": {
         "credit": "Buddy_5bbkqrb1",
         "price": 2.95,
+        "cash_price": None,
+        "formatted_price": "$2.95",
+        "deal_price": 2.78,
         "last_updated": "2023-12-10T17:48:46.584Z",
     },
     "premium_gas": {
         "credit": "Owner",
         "price": None,
         "cash_price": 3.35,
+        "formatted_price": None,
+        "deal_price": None,
         "last_updated": "2023-12-10T17:31:01.856Z",
     },
     "e85": {
         "credit": "Owner",
         "price": 2.83,
         "cash_price": None,
+        "formatted_price": "$2.83",
+        "deal_price": None,
         "last_updated": "2024-09-27T18:12:09.837Z",
     },
     "e15": {
         "credit": "Owner",
         "price": 3.33,
         "cash_price": 3.13,
+        "formatted_price": "$3.33",
+        "deal_price": None,
         "last_updated": "2024-09-27T18:12:09.837Z",
+    },
+    "last_updated": datetime(2025, 1, 9, 16, 12, 51, tzinfo=UTC),
+}
+
+CONFIG_DATA_CHEAPEST = {
+    CONF_NAME: "Cheapest Gas",
+    CONF_CHEAPEST: True,
+    CONF_FUEL_KEY: "regular_gas",
+    CONF_PRICE_TYPE: "best",
+    CONF_SOLVER: None,
+    CONF_TIMEOUT: DEFAULT_TIMEOUT,
+}
+
+OPTIONS_CHEAPEST = {
+    CONF_INTERVAL: 3600,
+    CONF_UOM: True,
+    CONF_GPS: False,
+    CONF_EV_CHARGING: False,
+    CONF_FETCH_GAS: True,
+}
+
+COORDINATOR_DATA_CHEAPEST = {
+    "station_id": "187725",
+    "name": "Shell",
+    "image_url": None,
+    "unit_of_measure": "dollars_per_gallon",
+    "currency": "USD",
+    "latitude": 33.460000,
+    "longitude": -112.500000,
+    "distance": 0.5,
+    "regular_gas": {
+        "credit": "user99",
+        "price": 2.89,
+        "cash_price": 2.79,
+        "formatted_price": "$2.89",
+        "deal_price": 2.72,
+        "last_updated": "2025-01-09T16:00:00.000Z",
     },
     "last_updated": datetime(2025, 1, 9, 16, 12, 51, tzinfo=UTC),
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2010,3 +2010,222 @@ async def test_cheapest_flow_invalid_solver(hass):
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cheapest"
     assert result["errors"] == {CONF_SOLVER: "invalid_url"}
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_invalid_station_id_format(hass):
+    r"""Manual flow rejects station IDs that don't match ^\d{1,20}$ (lines 451-452)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NAME: DEFAULT_NAME, CONF_STATION_ID: "abc-not-numeric"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {CONF_STATION_ID: "station_id"}
+
+
+@pytest.mark.asyncio
+async def test_postal_invalid_format(hass):
+    """Postal flow rejects postal codes that don't match the postal regex (lines 622-623)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "search"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "postal"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_POSTAL: "NOTVALID"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "postal"
+    assert result["errors"] == {CONF_POSTAL: "no_results"}
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_invalid_station_id_format(hass, integration):
+    """Reconfigure rejects non-numeric station IDs (lines 781-782)."""
+    entry = integration
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        {CONF_NAME: DEFAULT_NAME, CONF_STATION_ID: "abc-invalid", CONF_SOLVER: ""},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_STATION_ID: "station_id"}
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_cheapest_show_form(hass):
+    """Reconfigure for a cheapest entry shows the cheapest form (lines 775, 856)."""
+    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=CONFIG_DATA_CHEAPEST,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    assert reconfigure_result["step_id"] == "reconfigure"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_cheapest_success(hass):
+    """Reconfigure cheapest entry with valid data succeeds (lines 823-850)."""
+    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=CONFIG_DATA_CHEAPEST,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            {
+                CONF_NAME: "Updated Cheapest",
+                CONF_POSTAL: "90210",
+                CONF_FUEL_KEY: "premium_gas",
+                CONF_PRICE_TYPE: "cash",
+                CONF_SOLVER: "",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_NAME] == "Updated Cheapest"
+    assert entry.data[CONF_POSTAL] == "90210"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_cheapest_invalid_solver(hass):
+    """Reconfigure cheapest entry rejects invalid solver URL (lines 828-829)."""
+    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=CONFIG_DATA_CHEAPEST,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        {
+            CONF_NAME: "Cheapest Gas",
+            CONF_POSTAL: "",
+            CONF_FUEL_KEY: "regular_gas",
+            CONF_PRICE_TYPE: "best",
+            CONF_SOLVER: "not-a-valid-url",
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_SOLVER: "invalid_url"}
+
+
+@pytest.mark.asyncio
+async def test_station_list_cache_eviction(hass):
+    """Station coord cache evicts oldest entries when >= 50 flow IDs exist (lines 213-214)."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["station_coordinates_by_flow"] = {f"flow_{i}": {} for i in range(50)}
+
+    ev_station = {
+        "station_id": "ev001",
+        "name": "Test EV",
+        "street_address": "1 Main St",
+        "latitude": 33.5,
+        "longitude": -112.5,
+    }
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.location_search",
+            return_value={"results": []},
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.ev_stations_nearby",
+            return_value={"stations": [ev_station]},
+        ),
+    ):
+        await _get_station_list(hass, {"lat": 33.5, "lon": -112.5}, "new_flow_id")
+
+    cache = hass.data[DOMAIN]["station_coordinates_by_flow"]
+    assert len(cache) <= 41  # 50 - 10 evicted + 1 new
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_cheapest_clears_postal(hass):
+    """Reconfigure cheapest entry removes postal when submitted blank (line 843)."""
+    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
+
+    config_with_postal = {**CONFIG_DATA_CHEAPEST, CONF_POSTAL: "12345"}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=config_with_postal,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            {
+                CONF_NAME: "Cheapest Gas",
+                CONF_POSTAL: "",
+                CONF_FUEL_KEY: "regular_gas",
+                CONF_PRICE_TYPE: "best",
+                CONF_SOLVER: "",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert CONF_POSTAL not in entry.data

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -15,12 +15,15 @@ from custom_components.gasbuddy.config_flow import (
     validate_station,
 )
 from custom_components.gasbuddy.const import (
+    CONF_CHEAPEST,
     CONF_EV_CHARGING,
     CONF_FETCH_GAS,
+    CONF_FUEL_KEY,
     CONF_GPS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_POSTAL,
+    CONF_PRICE_TYPE,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -1908,3 +1911,102 @@ async def test_station_list_non_dict_validation(hass):
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["options"][CONF_EV_CHARGING] is False
+
+
+async def test_cheapest_flow_gps(hass):
+    """Test cheapest gas tracker flow using home coordinates (no postal)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.MENU
+
+    with patch(
+        "custom_components.gasbuddy.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "cheapest"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "cheapest"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Cheapest Gas",
+                CONF_POSTAL: "",
+                CONF_FUEL_KEY: "regular_gas",
+                CONF_PRICE_TYPE: "best",
+                CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Cheapest Gas"
+        assert result["data"][CONF_CHEAPEST] is True
+        assert result["data"][CONF_FUEL_KEY] == "regular_gas"
+        assert result["data"][CONF_PRICE_TYPE] == "best"
+        assert CONF_POSTAL not in result["data"]
+        assert result["data"][CONF_SOLVER] is None
+        assert result["options"][CONF_EV_CHARGING] is False
+        assert result["options"][CONF_FETCH_GAS] is True
+
+        await hass.async_block_till_done()
+        assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_cheapest_flow_postal(hass):
+    """Test cheapest gas tracker flow using postal code."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.MENU
+
+    with patch(
+        "custom_components.gasbuddy.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "cheapest"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Cheapest Gas Near Me",
+                CONF_POSTAL: "13201",
+                CONF_FUEL_KEY: "premium_gas",
+                CONF_PRICE_TYPE: "cash",
+                CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_CHEAPEST] is True
+        assert result["data"][CONF_FUEL_KEY] == "premium_gas"
+        assert result["data"][CONF_PRICE_TYPE] == "cash"
+        assert result["data"][CONF_POSTAL] == "13201"
+
+
+async def test_cheapest_flow_invalid_solver(hass):
+    """Test cheapest flow rejects invalid solver URL."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "cheapest"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cheapest"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Cheapest Gas",
+            CONF_POSTAL: "",
+            CONF_FUEL_KEY: "regular_gas",
+            CONF_PRICE_TYPE: "best",
+            CONF_SOLVER: "not-a-valid-url",
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cheapest"
+    assert result["errors"] == {CONF_SOLVER: "invalid_url"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2191,7 +2191,7 @@ async def test_station_list_cache_eviction(hass):
         await _get_station_list(hass, {"lat": 33.5, "lon": -112.5}, "new_flow_id")
 
     cache = hass.data[DOMAIN]["station_coordinates_by_flow"]
-    assert len(cache) <= 41  # 50 - 10 evicted + 1 new
+    assert len(cache) == 41  # 50 - 10 evicted + 1 new
 
 
 @pytest.mark.asyncio
@@ -2229,3 +2229,62 @@ async def test_reconfigure_cheapest_clears_postal(hass):
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert CONF_POSTAL not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_cheapest_flow_invalid_postal(hass):
+    """Cheapest flow rejects a postal code that fails _POSTAL_RE validation."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "cheapest"}
+    )
+    assert result["step_id"] == "cheapest"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Cheapest Gas",
+            CONF_POSTAL: "NOTVALID",
+            CONF_FUEL_KEY: "regular_gas",
+            CONF_PRICE_TYPE: "best",
+            CONF_SOLVER: "",
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cheapest"
+    assert CONF_POSTAL in result["errors"]
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_cheapest_invalid_postal(hass):
+    """Reconfigure cheapest entry rejects invalid postal code."""
+    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=CONFIG_DATA_CHEAPEST,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        {
+            CONF_NAME: "Cheapest Gas",
+            CONF_POSTAL: "NOTVALID",
+            CONF_FUEL_KEY: "regular_gas",
+            CONF_PRICE_TYPE: "best",
+            CONF_SOLVER: "",
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert CONF_POSTAL in result["errors"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -34,7 +34,7 @@ async def test_diagnostics(
 
     # Test Config Entry Diagnostics
     config_diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    assert config_diagnostics["config"]["data"]["station_id"] == 208656
+    assert config_diagnostics["config"]["data"]["station_id"] == "**REDACTED**"
     assert config_diagnostics["config"]["title"] == "Gas Station"
 
     # Test Device Diagnostics
@@ -44,6 +44,6 @@ async def test_diagnostics(
     assert device is not None
 
     device_diagnostics = await async_get_device_diagnostics(hass, entry, device)
-    assert device_diagnostics["station_id"] == "208656"
+    assert device_diagnostics["station_id"] == "**REDACTED**"
     assert device_diagnostics["unit_of_measure"] == "dollars_per_gallon"
     assert device_diagnostics["regular_gas"]["price"] == 2.95

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,13 +26,13 @@ async def test_setup_and_unload_entry(hass, mock_gasbuddy):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 
     assert await hass.config_entries.async_remove(entries[0].entry_id)
@@ -48,13 +48,13 @@ async def test_setup_and_unload_entry_v1(hass, mock_gasbuddy):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
     assert await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     assert len(hass.states.async_entity_ids(DOMAIN)) == 0
 
     assert await hass.config_entries.async_remove(entries[0].entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -477,6 +477,54 @@ async def test_extra_attrs_richer(hass, mock_gasbuddy, integration):
     assert attrs.get("amenities") == "ATM, Restrooms"
 
 
+async def test_deal_sensor_disabled_when_pay_status_false(
+    hass, mock_gasbuddy, entity_registry: er.EntityRegistry
+):
+    """Deal sensors stay disabled when pay_status is False even if deal_price is set."""
+    data_no_pay = {
+        **COORDINATOR_DATA,
+        "pay_status": False,
+        "regular_gas": {**COORDINATOR_DATA["regular_gas"], "deal_price": 2.50},
+    }
+    with patch(
+        "custom_components.gasbuddy.GasBuddyUpdateCoordinator._async_update_data",
+        return_value=data_no_pay,
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Gas Station",
+            data=CONFIG_DATA,
+            options={CONF_UOM: True, "gps": True, CONF_EV_CHARGING: False, CONF_FETCH_GAS: True},
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    deal_entry = entity_registry.async_get("sensor.gas_station_regular_gas_deal")
+    assert deal_entry is not None
+    assert deal_entry.disabled
+
+
+async def test_extra_attrs_deal_price_gated_on_pay_status(hass, mock_gasbuddy, integration):
+    """deal_price attribute is omitted from price sensors when pay_status is False."""
+    import copy  # noqa: PLC0415
+
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+    original_data = coordinator.data
+    patched_data = copy.deepcopy(original_data)
+    patched_data["pay_status"] = False
+    coordinator.data = patched_data
+
+    sensor = GasBuddySensor(SENSOR_TYPES["regular_gas"], coordinator, integration)
+    attrs = sensor.extra_state_attributes
+
+    coordinator.data = original_data  # restore
+
+    assert attrs is not None
+    assert "deal_price" not in attrs
+
+
 # ---------------------------------------------------------------------------
 # Coordinator cheapest-mode tests (coordinator.py lines 95, 247-290)
 # ---------------------------------------------------------------------------
@@ -633,3 +681,29 @@ async def test_fuels_list_enables_sensors(hass, entity_registry: er.EntityRegist
     diesel = entity_registry.async_get("sensor.gas_station_diesel")
     assert diesel is not None
     assert diesel.disabled_by is None
+
+
+async def test_coordinator_cheapest_no_valid_prices(hass):
+    """Cheapest mode raises UpdateFailed when all stations have no finite price."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    stations_no_price = [
+        {
+            "station_id": "999",
+            "name": "NoPriceStation",
+            "regular_gas": {"price": None, "cash_price": None, "deal_price": None},
+        },
+    ]
+    with (
+        patch.object(
+            coordinator._api,  # noqa: SLF001
+            "price_lookup_service",
+            return_value={"results": stations_no_price},
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -484,18 +484,18 @@ async def test_extra_attrs_richer(hass, mock_gasbuddy, integration):
     assert attrs.get("amenities") == "ATM, Restrooms"
 
 
-async def test_deal_sensor_disabled_when_pay_status_false(
+async def test_deal_sensor_enabled_without_pay_status(
     hass, mock_gasbuddy, entity_registry: er.EntityRegistry
 ):
-    """Deal sensors stay disabled when pay_status is False even if deal_price is set."""
-    data_no_pay = {
+    """Deal sensors enable when deal_price is present even without pay_status (cheapest mode)."""
+    data_cheapest_like = {
         **COORDINATOR_DATA,
-        "pay_status": False,
         "regular_gas": {**COORDINATOR_DATA["regular_gas"], "deal_price": 2.50},
     }
+    data_cheapest_like.pop("pay_status", None)
     with patch(
         "custom_components.gasbuddy.GasBuddyUpdateCoordinator._async_update_data",
-        return_value=data_no_pay,
+        return_value=data_cheapest_like,
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -510,17 +510,17 @@ async def test_deal_sensor_disabled_when_pay_status_false(
 
     deal_entry = entity_registry.async_get("sensor.gas_station_regular_gas_deal")
     assert deal_entry is not None
-    assert deal_entry.disabled
+    assert not deal_entry.disabled
 
 
-async def test_extra_attrs_deal_price_gated_on_pay_status(hass, mock_gasbuddy, integration):
-    """deal_price attribute is omitted from price sensors when pay_status is False."""
+async def test_extra_attrs_deal_price_present_without_pay_status(hass, mock_gasbuddy, integration):
+    """deal_price attribute appears when deal_price is set, even without pay_status (cheapest mode)."""
     import copy  # noqa: PLC0415
 
     coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
     original_data = coordinator.data
     patched_data = copy.deepcopy(original_data)
-    patched_data["pay_status"] = False
+    patched_data.pop("pay_status", None)
     coordinator.data = patched_data
 
     sensor = GasBuddySensor(SENSOR_TYPES["regular_gas"], coordinator, integration)
@@ -529,7 +529,8 @@ async def test_extra_attrs_deal_price_gated_on_pay_status(hass, mock_gasbuddy, i
     coordinator.data = original_data  # restore
 
     assert attrs is not None
-    assert "deal_price" not in attrs
+    assert "deal_price" in attrs
+    assert attrs["deal_price"] == patched_data["regular_gas"]["deal_price"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -27,7 +27,14 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import as_utc, parse_datetime
 from tests.common import load_fixture
 
-from .const import CONFIG_DATA, CONFIG_DATA_NO_UOM, OPTIONS_NO_UOM
+from .const import (
+    CONFIG_DATA,
+    CONFIG_DATA_CHEAPEST,
+    CONFIG_DATA_NO_UOM,
+    COORDINATOR_DATA,
+    OPTIONS_CHEAPEST,
+    OPTIONS_NO_UOM,
+)
 
 ATTR_ENTITY_PICTURE = "entity_picture"
 
@@ -468,3 +475,161 @@ async def test_extra_attrs_richer(hass, mock_gasbuddy, integration):
     assert attrs.get("star_rating") == 4.2
     assert attrs.get("address") == "1101 N Verrado Way, Buckeye, AZ"
     assert attrs.get("amenities") == "ATM, Restrooms"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator cheapest-mode tests (coordinator.py lines 95, 247-290)
+# ---------------------------------------------------------------------------
+
+_CHEAPEST_STATIONS = [
+    {
+        "station_id": "111",
+        "name": "Expensive",
+        "regular_gas": {"price": 4.00, "cash_price": 3.90, "deal_price": 3.80},
+    },
+    {
+        "station_id": "222",
+        "name": "Cheap",
+        "regular_gas": {"price": 3.20, "cash_price": 3.10, "deal_price": 3.00},
+    },
+]
+
+
+async def test_coordinator_cheapest_gps(hass):
+    """Cheapest mode picks lowest station via GPS (best price type)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": _CHEAPEST_STATIONS},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data["station_id"] == "222"
+    assert "last_updated" in data
+
+
+async def test_coordinator_cheapest_postal(hass):
+    """Cheapest mode uses postal code when configured."""
+    from custom_components.gasbuddy.const import CONF_POSTAL  # noqa: PLC0415
+
+    config = {**CONFIG_DATA_CHEAPEST, CONF_POSTAL: "12345"}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    stations = [
+        {
+            "station_id": "333",
+            "name": "Postal",
+            "regular_gas": {"price": 3.10, "cash_price": None, "deal_price": None},
+        }
+    ]
+    with patch.object(coordinator._api, "price_lookup_service", return_value={"results": stations}):  # noqa: SLF001
+        data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data["station_id"] == "333"
+
+
+async def test_coordinator_cheapest_no_stations(hass):
+    """Cheapest mode raises UpdateFailed when no station carries the fuel."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with (
+        patch.object(coordinator._api, "price_lookup_service", return_value={"results": []}),  # noqa: SLF001
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001
+
+
+async def test_coordinator_cheapest_api_error(hass):
+    """Cheapest mode wraps API errors as UpdateFailed."""
+    from py_gasbuddy.exceptions import APIError  # noqa: PLC0415
+
+    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with (
+        patch.object(coordinator._api, "price_lookup_service", side_effect=APIError("boom")),  # noqa: SLF001
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001
+
+
+async def test_coordinator_cheapest_sort_deal(hass):
+    """Cheapest mode sort by deal price."""
+    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
+
+    config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "deal"}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": _CHEAPEST_STATIONS},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "222"
+
+
+async def test_coordinator_cheapest_sort_cash(hass):
+    """Cheapest mode sort by cash price."""
+    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
+
+    config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "cash"}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": _CHEAPEST_STATIONS},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "222"
+
+
+async def test_coordinator_cheapest_sort_credit(hass):
+    """Cheapest mode sort by credit price (fallback else branch)."""
+    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
+
+    config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "credit"}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": _CHEAPEST_STATIONS},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "222"
+
+
+async def test_fuels_list_enables_sensors(hass, entity_registry: er.EntityRegistry):
+    """Fuels list in coordinator data enables sensors for carried fuels (sensor.py line 48)."""
+    data_with_fuels = {**COORDINATOR_DATA, "fuels": ["regular_gas", "diesel"]}
+    with patch(
+        "custom_components.gasbuddy.GasBuddyUpdateCoordinator._async_update_data",
+        return_value=data_with_fuels,
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="gas_station",
+            data=CONFIG_DATA,
+            options={CONF_UOM: True, "gps": True, CONF_EV_CHARGING: False, CONF_FETCH_GAS: True},
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    diesel = entity_registry.async_get("sensor.gas_station_diesel")
+    assert diesel is not None
+    assert diesel.disabled_by is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -46,7 +46,9 @@ async def test_sensors(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    # With enriched COORDINATOR_DATA: regular_gas, premium_gas, premium_gas_cash,
+    # e85, e15, e15_cash, regular_gas_deal, last_updated = 8 enabled sensors
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
@@ -59,15 +61,16 @@ async def test_sensors(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):
     assert state.attributes[ATTR_LATITUDE] == 33.459108
     assert state.attributes[ATTR_LONGITUDE] == -112.502745
     assert state.attributes[ATTR_ENTITY_PICTURE] == "https://images.gasbuddy.io/b/122.png"
-    state = hass.states.get("sensor.gas_station_midgrade_gas")
-    assert state
-    assert state.state == "unavailable"
+
+    # midgrade_gas not in station data → disabled by dynamic enabled_default → no state
+    assert hass.states.get("sensor.gas_station_midgrade_gas") is None
+
     state = hass.states.get("sensor.gas_station_premium_gas")
     assert state
     assert state.state == "unavailable"
 
-    # enable disabled sensor
-    entity_id = "sensor.gas_station_premium_gas_cash"
+    # regular_gas_cash is disabled (cash_price=None in fixture)
+    entity_id = "sensor.gas_station_regular_gas_cash"
     entity_entry = entity_registry.async_get(entity_id)
 
     assert entity_entry
@@ -83,9 +86,10 @@ async def test_sensors(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     await hass.async_block_till_done()
 
+    # cash_price=None → unavailable after enable
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "3.35"
+    assert state.state == "unavailable"
 
     state = hass.states.get("sensor.gas_station_last_updated")
     assert state
@@ -105,7 +109,7 @@ async def test_sensors_no_uom(hass, mock_gasbuddy, entity_registry: er.EntityReg
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 8
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
@@ -117,14 +121,15 @@ async def test_sensors_no_uom(hass, mock_gasbuddy, entity_registry: er.EntityReg
     assert state.attributes["unit_of_measurement"] == "USD"
     assert state.attributes[ATTR_LATITUDE] == 33.459108
     assert state.attributes[ATTR_LONGITUDE] == -112.502745
-    state = hass.states.get("sensor.gas_station_midgrade_gas")
-    assert state
-    assert state.state == "unavailable"
+
+    # midgrade_gas not in station data → disabled by dynamic enabled_default → no state
+    assert hass.states.get("sensor.gas_station_midgrade_gas") is None
+
     state = hass.states.get("sensor.gas_station_premium_gas")
     assert state
     assert state.state == "unavailable"
 
-    # enable disabled sensor
+    # e85_cash is disabled (cash_price=None in fixture)
     entity_id = "sensor.gas_station_e85_cash"
     entity_entry = entity_registry.async_get(entity_id)
 
@@ -158,6 +163,7 @@ async def test_sensors_cad(hass, mock_gasbuddy_cad, entity_registry: er.EntityRe
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    # CAD data has regular_gas + premium_gas + premium_gas_cash (cash=145.2) + last_updated = 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -171,15 +177,21 @@ async def test_sensors_cad(hass, mock_gasbuddy_cad, entity_registry: er.EntityRe
     assert state.attributes[ATTR_LATITUDE] == 33.459108
     assert state.attributes[ATTR_LONGITUDE] == -112.502745
     assert ATTR_ENTITY_PICTURE not in state.attributes
+
     state = hass.states.get("sensor.gas_station_midgrade_gas")
-    assert state
-    assert state.state == "unavailable"
+    assert state is None
+
     state = hass.states.get("sensor.gas_station_premium_gas")
     assert state
     assert state.state == "1.531"
 
-    # enable disabled sensor
-    entity_id = "sensor.gas_station_premium_gas_cash"
+    # premium_gas_cash is now enabled (cash_price=145.2 present)
+    state = hass.states.get("sensor.gas_station_premium_gas_cash")
+    assert state
+    assert state.state == "1.452"
+
+    # regular_gas_cash remains disabled (no cash_price key in CAD regular_gas fixture)
+    entity_id = "sensor.gas_station_regular_gas_cash"
     entity_entry = entity_registry.async_get(entity_id)
 
     assert entity_entry
@@ -197,7 +209,7 @@ async def test_sensors_cad(hass, mock_gasbuddy_cad, entity_registry: er.EntityRe
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "1.452"
+    assert state.state == "unavailable"
 
 
 async def test_sensor_robustness(hass, mock_gasbuddy, integration):
@@ -376,3 +388,83 @@ async def test_redact_fallback():
     assert "value" in redacted
     assert "12.34" not in redacted
     assert "**REDACTED**" in redacted
+
+
+async def test_dynamic_enabled_deal(hass, mock_gasbuddy, entity_registry: er.EntityRegistry):
+    """Test that deal sensors are enabled only when deal_price is present."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Gas Station",
+        data=CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # regular_gas has deal_price=2.78 → deal sensor should be enabled
+    deal_entry = entity_registry.async_get("sensor.gas_station_regular_gas_deal")
+    assert deal_entry is not None
+    assert not deal_entry.disabled
+
+    # premium_gas has deal_price=None → deal sensor should be disabled
+    premium_deal_entry = entity_registry.async_get("sensor.gas_station_premium_gas_deal")
+    assert premium_deal_entry is not None
+    assert premium_deal_entry.disabled
+
+    # e85 has deal_price=None → deal sensor should be disabled
+    e85_deal_entry = entity_registry.async_get("sensor.gas_station_e85_deal")
+    assert e85_deal_entry is not None
+    assert e85_deal_entry.disabled
+
+
+async def test_deal_native_value(hass, mock_gasbuddy, integration):
+    """Test deal sensor returns deal_price."""
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+
+    sensor = GasBuddySensor(SENSOR_TYPES["regular_gas_deal"], coordinator, integration)
+    # regular_gas.deal_price = 2.78
+    assert sensor.native_value == 2.78
+
+
+async def test_deal_sensor_unavailable(hass, mock_gasbuddy, integration):
+    """Test deal sensor is unavailable when deal_price is None."""
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+
+    # premium_gas.deal_price = None
+    sensor = GasBuddySensor(SENSOR_TYPES["premium_gas_deal"], coordinator, integration)
+    assert sensor.available is False
+
+
+async def test_open_status_sensor(hass, mock_gasbuddy, integration):
+    """Test open_status sensor returns the station status string."""
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+
+    sensor = GasBuddySensor(SENSOR_TYPES["open_status"], coordinator, integration)
+    assert sensor.native_value == "open"
+    # open_status is a non-price, non-EV sensor → no extra attributes
+    assert sensor.extra_state_attributes is None
+
+
+async def test_station_name_sensor(hass, mock_gasbuddy, integration):
+    """Test station_name sensor returns the station name string."""
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+
+    sensor = GasBuddySensor(SENSOR_TYPES["station_name"], coordinator, integration)
+    assert sensor.native_value == "Costco"
+    assert sensor.extra_state_attributes is None
+
+
+async def test_extra_attrs_richer(hass, mock_gasbuddy, integration):
+    """Test price sensor attributes include new enriched fields."""
+    coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
+
+    sensor = GasBuddySensor(SENSOR_TYPES["regular_gas"], coordinator, integration)
+    attrs = sensor.extra_state_attributes
+
+    assert attrs is not None
+    assert attrs.get("formatted_price") == "$2.95"
+    assert attrs.get("deal_price") == 2.78
+    assert attrs.get("phone") == "555-555-5555"
+    assert attrs.get("star_rating") == 4.2
+    assert attrs.get("address") == "1101 N Verrado Way, Buckeye, AZ"
+    assert attrs.get("amenities") == "ATM, Restrooms"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -273,14 +273,21 @@ async def test_sensor_coverage_edge_cases(hass, mock_gasbuddy, integration):
     """Test sensor edge cases for 100% coverage."""
     coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
 
-    # Test Line 91: price is 0 (falsy but not None)
-    # available will return True, but native_value returns None
+    # Test: price is 0 — valid price, sensor is available and returns 0
     with patch.dict(
         coordinator.data,
         {"regular_gas": {"price": 0, "last_updated": "2023-12-10T17:48:46.584Z"}},
     ):
         sensor = GasBuddySensor(SENSOR_TYPES["regular_gas"], coordinator, integration)
         assert sensor.available is True
+        assert sensor.native_value == 0
+
+    # Test: price is None — native_value returns None (sensor.py line 148)
+    with patch.dict(
+        coordinator.data,
+        {"regular_gas": {"price": None, "last_updated": "2023-12-10T17:48:46.584Z"}},
+    ):
+        sensor = GasBuddySensor(SENSOR_TYPES["regular_gas"], coordinator, integration)
         assert sensor.native_value is None
 
     # Test Line 115: currency and uom missing when CONF_UOM is True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -306,3 +306,63 @@ async def test_clear_cache(
                 return_response=False,
             )
         assert "Device_entry: None" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests
+# ---------------------------------------------------------------------------
+
+
+async def test_lookup_gps_invalid_solver(hass, mock_gasbuddy, mock_aioclient):
+    """lookup_gps raises ServiceValidationError for invalid solver URL (services.py line 53)."""
+    from homeassistant.exceptions import ServiceValidationError  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Gas Station",
+        data=CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="Invalid FlareSolverr URL"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_LOOKUP_GPS,
+            {
+                ATTR_ENTITY_ID: "sensor.gas_station_regular_gas",
+                ATTR_LIMIT: 5,
+                ATTR_SOLVER: "not-a-valid-url",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+
+async def test_clear_cache_no_config_entry(hass, mock_gasbuddy, mock_aioclient, caplog):
+    """clear_cache raises ValueError when device has no config entry (services.py line 295)."""
+    from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Gas Station",
+        data=CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_device = MagicMock()
+    mock_device.config_entries = set()
+
+    with patch("custom_components.gasbuddy.services.dr.async_get") as mock_reg:
+        mock_reg.return_value.async_get.return_value = mock_device
+        with pytest.raises(ValueError, match="No config entry found"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CLEAR_CACHE,
+                {ATTR_DEVICE_ID: "fake_device_id"},
+                blocking=True,
+                return_response=False,
+            )


### PR DESCRIPTION
## Summary

- **Deal price sensors**: New `*_deal` sensor variants for each fuel type (Regular, Midgrade, Premium, Diesel, E85, UNL88) exposing the GasBuddy Pay / Flash Deal discounted price from `offers.discounts.pwgbDiscount`. Gated on `pay_status=True` so stations without GasBuddy Pay eligibility never expose deal sensors.
- **Dynamic `entity_registry_enabled_default`**: Fuel sensors are enabled only when a station actually sells that fuel; deal sensors are additionally gated on `pay_status` and a non-null `deal_price`; cash sensors gate on `cash_price` presence.
- **Richer `extra_state_attributes`**: Gas price sensors now expose `formatted_price`, `deal_price`, `phone`, `star_rating`, `address`, and `amenities`.
- **Open Status and Station Name sensors**: New text sensors for station open/closed status and station name.
- **Cheapest Nearby Gas mode**: New config flow entry type that queries nearby stations on each refresh and always surfaces the current cheapest for a chosen fuel and price type (credit / cash / deal / best).
- **Security hardening**: SSRF protection on solver URL, postal code validation, diagnostics redaction for GPS coordinates and station IDs.
- **Config flow fixes**: Dropdown selectors for fuel/price type, translation strings for new sensors and flow steps, `vol.Match` → `vol.All`/`vol.Strip` fix that was returning HTTP 500.
- **Bumps `py_gasbuddy` to 0.6.0** which adds parity fields (`openStatus`, `amenities`, `hours`, `phone`, `hasActiveOutage`) to the `locationBySearchTerm` price query and corrects `payStatus` semantics (`null` = Flash Deal eligible; `{isPayAvailable: false}` = GasBuddy Pay disabled).

## Test plan

- [x] All tests pass (`pytest tests/ -q`, 100% coverage)
- [x] Deal sensors enabled only when `pay_status=True` and `deal_price` present; unavailable otherwise
- [x] Dynamic enabled_default: midgrade/diesel disabled for stations that don't carry those fuels
- [x] Open Status sensor shows `open`/`closed` correctly
- [x] Cheapest Gas mode: coordinator picks lowest-price station for selected fuel/price type on each refresh; Station Name sensor reflects whichever station is currently cheapest
- [x] Costco-type stations (`{isPayAvailable: false}`): deal sensors disabled, deal attributes absent
- [x] Flash Deal stations (`payStatus: null`): deal sensors enabled when discount present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "cheapest" tracker option with fuel/price-type selection, optional zipcode, and new "deal", "station name", and "station status" sensors with richer metadata.

* **Bug Fixes**
  * Stronger input validation (solver URLs, station IDs, postal codes), bounded timeouts/name lengths, improved per-flow cache with eviction, and tightened debug logging.

* **Documentation**
  * UI strings and translations updated (en, es, fr, pt).

* **Privacy**
  * Diagnostics redact additional sensitive fields (solver, postal, location, station id).

* **Tests**
  * Expanded coverage for cheapest flows, sensors, services, diagnostics, and cache behavior.

* **Chores**
  * Dependency and lint configuration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->