### PR TITLE
chore: drop transitive py_gasbuddy deps from manifest

### DIFF
--- a/custom_components/gasbuddy/manifest.json
+++ b/custom_components/gasbuddy/manifest.json
@@ -13,8 +13,6 @@
     "gasbuddy"
   ],
   "requirements": [
-    "aiofiles",
-    "backoff",
     "py_gasbuddy==0.5.1"
   ],
   "version": "0.0.0-dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-aiofiles
-backoff
 py_gasbuddy==0.5.1


### PR DESCRIPTION
## Summary
- `aiofiles` and `backoff` are runtime dependencies of `py_gasbuddy`, not used directly here. Remove them from `manifest.json` and `requirements.txt` so the dependency tree has a single source of truth.

## Test plan
- [ ] HA installs the integration cleanly via HACS and resolves `aiofiles`/`backoff` transitively through `py_gasbuddy`.
- [ ] No code in `custom_components/gasbuddy/` imports either package directly (verified with grep).