### PR TITLE
fix: share CSRF cache file across coordinator, config flow, services

### DIFF
--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -40,6 +40,7 @@ def _cache_path(hass: HomeAssistant) -> str:
     """Return the shared CSRF-token cache file path."""
     return f"{hass.config.config_dir}/{CACHE_FILE_NAME}"
 
+
 _LOGGER = logging.getLogger(__name__)
 MENU_OPTIONS = ["manual", "search"]
 MENU_SEARCH = ["home", "postal"]

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
+    CACHE_FILE_NAME,
     CONF_EV_CHARGING,
     CONF_FETCH_GAS,
     CONF_GPS,
@@ -33,6 +34,11 @@ from .const import (
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
+
+
+def _cache_path(hass: HomeAssistant) -> str:
+    """Return the shared CSRF-token cache file path."""
+    return f"{hass.config.config_dir}/{CACHE_FILE_NAME}"
 
 _LOGGER = logging.getLogger(__name__)
 MENU_OPTIONS = ["manual", "search"]
@@ -75,6 +81,7 @@ async def validate_station(
         check = await py_gasbuddy.GasBuddy(
             solver_url=solver,
             station_id=station,
+            cache_file=_cache_path(hass),
             session=async_get_clientsession(hass),
         ).price_lookup()
         if "errors" not in check:
@@ -98,6 +105,7 @@ async def validate_station(
     try:
         ev_gb = py_gasbuddy.GasBuddy(
             solver_url=solver,
+            cache_file=_cache_path(hass),
             session=async_get_clientsession(hass),
         )
         val_lat = lat if lat is not None else hass.config.latitude
@@ -151,6 +159,7 @@ async def _get_station_list(
     try:
         stations = await py_gasbuddy.GasBuddy(
             solver_url=solver,
+            cache_file=_cache_path(hass),
             session=async_get_clientsession(hass),
         ).location_search(lat=lat, lon=lon, zipcode=postal)
     except MissingSearchData as ex:
@@ -172,6 +181,7 @@ async def _get_station_list(
         try:
             res = await py_gasbuddy.GasBuddy(
                 solver_url=solver,
+                cache_file=_cache_path(hass),
                 session=async_get_clientsession(hass),
             ).price_lookup_service(zipcode=postal)
             if res.get("results"):
@@ -186,6 +196,7 @@ async def _get_station_list(
         try:
             ev_gb = py_gasbuddy.GasBuddy(
                 solver_url=solver,
+                cache_file=_cache_path(hass),
                 session=async_get_clientsession(hass),
             )
             ev_res = await ev_gb.ev_stations_nearby(

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -24,6 +24,11 @@ DEFAULT_NAME = "Gas Station"
 DEFAULT_TIMEOUT = 60000
 CONFIG_VER = 7
 
+# CSRF token cache, shared across the coordinator, config flow, and services
+# so they all benefit from a single fetched token (and don't each hammer the
+# CSRF endpoint on installs where Cloudflare is rate-limiting).
+CACHE_FILE_NAME = ".storage/gasbuddy_cache"
+
 # hass.data attributes
 ATTR_DEVICE_ID = "device_id"
 ATTR_IMAGEURL = "image_url"

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CACHE_FILE_NAME,
     CONF_EV_CHARGING,
     CONF_INTERVAL,
     CONF_NAME,
@@ -66,7 +67,7 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.interval = self._get_interval()
         self._data: dict[Any, Any] = {}
-        self._cache_file = f"{self.hass.config.config_dir}/.storage/gasbuddy_cache"
+        self._cache_file = f"{self.hass.config.config_dir}/{CACHE_FILE_NAME}"
         self._api = GasBuddy(
             solver_url=config.data.get(CONF_SOLVER),
             station_id=config.data[CONF_STATION_ID],

--- a/custom_components/gasbuddy/services.py
+++ b/custom_components/gasbuddy/services.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_POSTAL_CODE,
     ATTR_RADIUS,
     ATTR_SOLVER,
+    CACHE_FILE_NAME,
     COORDINATOR,
     DOMAIN,
     SERVICE_CLEAR_CACHE,
@@ -34,6 +35,11 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _cache_path(hass: HomeAssistant) -> str:
+    """Return the shared CSRF-token cache file path."""
+    return f"{hass.config.config_dir}/{CACHE_FILE_NAME}"
 
 
 class GasBuddyServices:
@@ -130,7 +136,11 @@ class GasBuddyServices:
             solver = service.data[ATTR_SOLVER]
 
         results = {}
-        api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
+        api = GasBuddy(
+            solver_url=solver,
+            cache_file=_cache_path(self.hass),
+            session=async_get_clientsession(self.hass),
+        )
         for entity_id in entity_ids:
             try:
                 entity = self.hass.states.get(entity_id)
@@ -162,6 +172,7 @@ class GasBuddyServices:
         try:
             results = await GasBuddy(
                 solver_url=solver,
+                cache_file=_cache_path(self.hass),
                 session=async_get_clientsession(self.hass),
             ).price_lookup_service(zipcode=zipcode, limit=limit)
         except (APIError, LibraryError, CSRFTokenMissing) as ex:
@@ -186,7 +197,11 @@ class GasBuddyServices:
             solver = service.data[ATTR_SOLVER]
 
         results = {}
-        api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
+        api = GasBuddy(
+            solver_url=solver,
+            cache_file=_cache_path(self.hass),
+            session=async_get_clientsession(self.hass),
+        )
         for entity_id in entity_ids:
             try:
                 entity = self.hass.states.get(entity_id)
@@ -228,7 +243,11 @@ class GasBuddyServices:
             solver = service.data[ATTR_SOLVER]
 
         results = {}
-        api = GasBuddy(solver_url=solver, session=async_get_clientsession(self.hass))
+        api = GasBuddy(
+            solver_url=solver,
+            cache_file=_cache_path(self.hass),
+            session=async_get_clientsession(self.hass),
+        )
         try:
             res = await api.price_lookup_service(zipcode=zipcode)
             lat = None


### PR DESCRIPTION
## Summary

Root cause of #232. Without an explicit `cache_file`, `py_gasbuddy.GasBuddy` falls back to `~/.cache/py_gasbuddy/token`, while the coordinator already caches at `<config_dir>/.storage/gasbuddy_cache`. The config flow and services therefore couldn't see the token cached by a previous successful setup and re-fetched a CSRF token on every call — which is what Cloudflare blocks on first install, producing the misleading "Invalid station ID" error.

- Add `CACHE_FILE_NAME` to `const.py` (single source of truth for the path).
- Add a small `_cache_path(hass)` helper in both `config_flow.py` and `services.py`.
- Pass `cache_file=_cache_path(hass)` to all 8 `GasBuddy(...)` constructions in those files.
- Point `coordinator.py` at the same constant.

## Test plan
- [x] Full suite: `pytest -q` → 67 passed, coverage 100%.

## Related
Closes #232 (root cause). The config-flow error-key surfacing for Cloudflare-specific failures will be a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized CSRF token caching across price lookup and station search operations to improve performance and reduce redundant authentication requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->