### PR TITLE
fix: register update_listener unsub with async_on_unload

### DIFF
--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if updated_config != config_entry.options:
         hass.config_entries.async_update_entry(config_entry, options=updated_config)
 
-    config_entry.add_update_listener(update_listener)
+    config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
     coordinator = GasBuddyUpdateCoordinator(hass, config_entry)
 
     # Fetch initial data so we have data when entities subscribe


### PR DESCRIPTION
## Summary
- `config_entry.add_update_listener` returns an unsubscribe callback. Currently we throw it away, so the listener accumulates across reloads — every options-flow save runs `async_setup_entry` again and attaches a new listener.
- After N saves, the next save triggers N reload cascades. Audit flagged this as a contributor to #216.
- Wrap in `config_entry.async_on_unload(...)`.

## Test plan
- [x] `pytest -q` → 67 passed (no behavior change for first setup; effect is on reload cleanup).