### PR TITLE
fix(config_flow): show a useful error when Cloudflare blocks the CSRF call

### DIFF
--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -441,7 +441,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = False
 
             if not validate:
-                self._errors[CONF_STATION_ID] = "station_id"
+                # Keep a more specific error (e.g. "cloudflare") if a handler
+                # above already set one; otherwise fall back to "station_id".
+                self._errors.setdefault(CONF_STATION_ID, "station_id")
             else:
                 self._data.update(user_input)
                 if isinstance(validate, dict):
@@ -551,7 +553,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = False
 
             if not validate:
-                self._errors[CONF_STATION_ID] = "station_id"
+                # Keep a more specific error (e.g. "cloudflare") if a handler
+                # above already set one; otherwise fall back to "station_id".
+                self._errors.setdefault(CONF_STATION_ID, "station_id")
                 return await self._show_config_home2(user_input)
             if isinstance(validate, dict):
                 self._data["latitude"] = validate.get("latitude")
@@ -655,7 +659,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = False
 
             if not validate:
-                self._errors[CONF_STATION_ID] = "station_id"
+                # Keep a more specific error (e.g. "cloudflare") if a handler
+                # above already set one; otherwise fall back to "station_id".
+                self._errors.setdefault(CONF_STATION_ID, "station_id")
                 return await self._show_config_station_list(user_input)
             if isinstance(validate, dict):
                 self._data["latitude"] = validate.get("latitude")
@@ -724,7 +730,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = False
 
             if not validate:
-                self._errors[CONF_STATION_ID] = "station_id"
+                # Keep a more specific error (e.g. "cloudflare") if a handler
+                # above already set one; otherwise fall back to "station_id".
+                self._errors.setdefault(CONF_STATION_ID, "station_id")
 
             if len(self._errors) == 0:
                 options = dict(entry.options)

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -7,7 +7,12 @@ import re
 from typing import Any
 
 import py_gasbuddy
-from py_gasbuddy.exceptions import APIError, LibraryError, MissingSearchData
+from py_gasbuddy.exceptions import (
+    APIError,
+    CSRFTokenMissing,
+    LibraryError,
+    MissingSearchData,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -47,6 +52,26 @@ class SearchFailed(HomeAssistantError):
     """Error to indicate the search failed."""
 
 
+class CloudflareBlocked(HomeAssistantError):
+    """Error to indicate the CSRF/Cloudflare check is blocking requests."""
+
+
+def _csrf_blocked_via_state(gb: py_gasbuddy.GasBuddy) -> bool:
+    """Return True if a just-failed call left the client without a CSRF token.
+
+    py_gasbuddy 0.6.0 catches ``CSRFTokenMissing`` inside its own
+    ``process_request`` and re-raises a content-less ``LibraryError``
+    upstream — so the caller can't distinguish "Cloudflare blocked
+    the token fetch" from "GasBuddy returned an error for this
+    station ID" by inspecting the exception. Instead, inspect the
+    client's post-call state: ``_tag`` stays empty exactly when the
+    CSRF round-trip never succeeded. Private attribute, but stable
+    across the recent py_gasbuddy releases — once the library exposes
+    a structured signal (see follow-up issue) we should switch.
+    """
+    return getattr(gb, "_tag", None) == ""
+
+
 def validate_url(url: str) -> bool:
     """Validate user input URL."""
     pattern = re.compile(
@@ -71,12 +96,13 @@ async def validate_station(
 ) -> dict[str, Any] | bool:
     """Validate station ID."""
     price_error = None
+    gb = py_gasbuddy.GasBuddy(
+        solver_url=solver,
+        station_id=station,
+        session=async_get_clientsession(hass),
+    )
     try:
-        check = await py_gasbuddy.GasBuddy(
-            solver_url=solver,
-            station_id=station,
-            session=async_get_clientsession(hass),
-        ).price_lookup()
+        check = await gb.price_lookup()
         if "errors" not in check:
             gas_lat = check.get("latitude")
             gas_lon = check.get("longitude")
@@ -91,7 +117,17 @@ async def validate_station(
                 "latitude": gas_lat,
                 "longitude": gas_lon,
             }
+    except CSRFTokenMissing as ex:
+        # Forward-compat: a future py_gasbuddy release may propagate
+        # this exception instead of swallowing it.
+        raise CloudflareBlocked from ex
     except (APIError, LibraryError) as ex:
+        # The EV path below would hit the same wall, so surface a
+        # distinct error class when the cause was specifically the
+        # CSRF/Cloudflare block — masking it as "Invalid station ID"
+        # leaves users with no actionable diagnosis (#232).
+        if _csrf_blocked_via_state(gb):
+            raise CloudflareBlocked from ex
         _LOGGER.warning("Error validating station via price_lookup: %s. Trying EV check...", ex)
         price_error = ex
 
@@ -398,6 +434,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = await validate_station(
                     self.hass, user_input[CONF_STATION_ID], user_input[CONF_SOLVER]
                 )
+            except CloudflareBlocked:
+                self._errors[CONF_STATION_ID] = "cloudflare"
+                validate = False
             except InvalidStation:
                 validate = False
 
@@ -505,6 +544,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     lat=lat,
                     lon=lon,
                 )
+            except CloudflareBlocked:
+                self._errors[CONF_STATION_ID] = "cloudflare"
+                validate = False
             except InvalidStation:
                 validate = False
 
@@ -606,6 +648,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     lat=lat,
                     lon=lon,
                 )
+            except CloudflareBlocked:
+                self._errors[CONF_STATION_ID] = "cloudflare"
+                validate = False
             except InvalidStation:
                 validate = False
 
@@ -672,6 +717,9 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validate = await validate_station(
                     self.hass, user_input[CONF_STATION_ID], user_input[CONF_SOLVER]
                 )
+            except CloudflareBlocked:
+                self._errors[CONF_STATION_ID] = "cloudflare"
+                validate = False
             except InvalidStation:
                 validate = False
 

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -7,12 +7,7 @@ import re
 from typing import Any
 
 import py_gasbuddy
-from py_gasbuddy.exceptions import (
-    APIError,
-    CSRFTokenMissing,
-    LibraryError,
-    MissingSearchData,
-)
+from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, LibraryError, MissingSearchData
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -52,19 +52,24 @@ class CloudflareBlocked(HomeAssistantError):
 
 
 def _csrf_blocked_via_state(gb: py_gasbuddy.GasBuddy) -> bool:
-    """Return True if a just-failed call left the client without a CSRF token.
+    """Return True if the just-failed call hit a CSRF/Cloudflare block.
 
-    py_gasbuddy 0.6.0 catches ``CSRFTokenMissing`` inside its own
-    ``process_request`` and re-raises a content-less ``LibraryError``
-    upstream — so the caller can't distinguish "Cloudflare blocked
-    the token fetch" from "GasBuddy returned an error for this
-    station ID" by inspecting the exception. Instead, inspect the
-    client's post-call state: ``_tag`` stays empty exactly when the
-    CSRF round-trip never succeeded. Private attribute, but stable
-    across the recent py_gasbuddy releases — once the library exposes
-    a structured signal (see follow-up issue) we should switch.
+    py_gasbuddy catches the underlying error inside its own
+    ``process_request`` and surfaces a content-less ``LibraryError``,
+    so the caller can't tell "Cloudflare blocked the token fetch" from
+    "GasBuddy returned an error for this station ID" by inspecting the
+    exception. Instead, inspect the client's post-call state. The
+    ``_cf_last`` sentinel is ``None`` before any request, ``True`` after
+    a request that returned parseable JSON, and ``False`` only when the
+    last round-trip got a non-JSON body or a 403/non-200 status, which
+    is the Cloudflare-block signature. We deliberately match ``is False``
+    (not falsy) so the ``None`` initial state, the one a mocked or
+    never-dispatched client reports, is not mistaken for a block.
+    Private attribute, but stable across recent py_gasbuddy releases;
+    once the library exposes a structured signal (see follow-up issue)
+    we should switch.
     """
-    return getattr(gb, "_tag", None) == ""
+    return getattr(gb, "_cf_last", None) is False
 
 
 def validate_url(url: str) -> bool:

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -6,7 +6,8 @@
         "error": {
             "station_id": "Invalid station ID",
             "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "invalid_url": "Not a valid URL.",
+            "cloudflare": "Couldn't fetch a CSRF token from GasBuddy (Cloudflare is blocking requests). Configure a FlareSolverr URL in the optional field and try again."
         },
         "step": {
             "user": {

--- a/custom_components/gasbuddy/translations/en.json
+++ b/custom_components/gasbuddy/translations/en.json
@@ -6,7 +6,8 @@
         "error": {
             "station_id": "Invalid station ID",
             "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "invalid_url": "Not a valid URL.",
+            "cloudflare": "Couldn't fetch a CSRF token from GasBuddy (Cloudflare is blocking requests). Configure a FlareSolverr URL in the optional field and try again."
         },
         "step": {
             "user": {

--- a/custom_components/gasbuddy/translations/es.json
+++ b/custom_components/gasbuddy/translations/es.json
@@ -6,7 +6,8 @@
         "error": {
             "station_id": "ID de estación inválido",
             "no_results": "No se encontraron estaciones en esta área.",
-            "invalid_url": "URL no válida."
+            "invalid_url": "URL no válida.",
+            "cloudflare": "No se pudo obtener un token CSRF de GasBuddy (Cloudflare está bloqueando las solicitudes). Configure una URL de FlareSolverr en el campo opcional e inténtelo de nuevo."
         },
         "step": {
             "user": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test config flow."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from aioresponses import CallbackResult
@@ -9,8 +10,10 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.gasbuddy.config_flow import (
+    CloudflareBlocked,
     InvalidStation,
     SearchFailed,
+    _csrf_blocked_via_state,  # noqa: PLC2701
     _get_station_list,  # noqa: PLC2701
     validate_station,
 )
@@ -1550,6 +1553,40 @@ async def test_validate_station_api_error(hass):
             side_effect=APIError("test error"),
         ),
         pytest.raises(InvalidStation),
+    ):
+        await validate_station(hass, 123, None)
+
+
+@pytest.mark.parametrize(
+    ("cf_last", "blocked"),
+    [
+        (False, True),  # last round-trip failed the CSRF/Cloudflare check
+        (None, False),  # never dispatched (e.g. mocked client) is not a block
+        (True, False),  # last round-trip returned parseable JSON
+    ],
+)
+async def test_csrf_blocked_via_state_signal(cf_last, blocked):
+    """Only ``_cf_last is False`` counts as a block; ``None`` must not."""
+    assert _csrf_blocked_via_state(SimpleNamespace(_cf_last=cf_last)) is blocked
+
+
+async def test_csrf_blocked_via_state_missing_attr():
+    """A client without ``_cf_last`` is treated as not blocked."""
+    assert _csrf_blocked_via_state(SimpleNamespace()) is False
+
+
+async def test_validate_station_cloudflare_blocked(hass):
+    """Test validate_station raises CloudflareBlocked when the CSRF probe trips."""
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup",
+            side_effect=APIError("blocked"),
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            return_value=True,
+        ),
+        pytest.raises(CloudflareBlocked),
     ):
         await validate_station(hass, 123, None)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from aioresponses import CallbackResult
-from py_gasbuddy.exceptions import APIError, MissingSearchData
+from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, MissingSearchData
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -1585,6 +1585,18 @@ async def test_validate_station_cloudflare_blocked(hass):
         patch(
             "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
             return_value=True,
+        ),
+        pytest.raises(CloudflareBlocked),
+    ):
+        await validate_station(hass, 123, None)
+
+
+async def test_validate_station_csrf_token_missing(hass):
+    """A propagated CSRFTokenMissing maps straight to CloudflareBlocked."""
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup",
+            side_effect=CSRFTokenMissing,
         ),
         pytest.raises(CloudflareBlocked),
     ):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1957,3 +1957,146 @@ async def test_station_list_non_dict_validation(hass):
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["options"][CONF_EV_CHARGING] is False
+
+
+async def test_reconfigure_cloudflare_blocked(hass, integration):
+    """Reconfigure flow surfaces the cloudflare error on a CSRF block."""
+    entry = integration
+
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        side_effect=CloudflareBlocked,
+    ):
+        reconfigure_result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+        assert reconfigure_result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_STATION_ID: "123",
+                CONF_SOLVER: "",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {CONF_STATION_ID: "cloudflare"}
+
+
+async def test_form_manual_cloudflare_blocked(hass):
+    """Manual flow surfaces the cloudflare error on a CSRF block."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        side_effect=CloudflareBlocked,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "manual"}
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_STATION_ID: "123",
+                CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
+        assert result["errors"] == {CONF_STATION_ID: "cloudflare"}
+
+
+async def test_home2_cloudflare_blocked(hass):
+    """home2 flow surfaces the cloudflare error on a CSRF block."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "search"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "home"}
+    )
+
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow._get_station_list",
+            return_value={"32394": "Holiday @ 400 4th St SE"},
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow.validate_station",
+            side_effect=CloudflareBlocked,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_SOLVER: SOLVER_URL}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "home2"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_STATION_ID: "32394",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "home2"
+        assert result["errors"] == {CONF_STATION_ID: "cloudflare"}
+
+
+async def test_station_list_cloudflare_blocked(hass):
+    """station_list flow surfaces the cloudflare error on a CSRF block."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "search"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "postal"}
+    )
+
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow._get_station_list",
+            return_value={"32394": "Holiday @ 400 4th St SE"},
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow.validate_station",
+            side_effect=CloudflareBlocked,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_POSTAL: "55904",
+                CONF_SOLVER: SOLVER_URL,
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "station_list"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_STATION_ID: "32394",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "station_list"
+        assert result["errors"] == {CONF_STATION_ID: "cloudflare"}


### PR DESCRIPTION
## Summary
- When py_gasbuddy can't fetch a CSRF token (Cloudflare interstitial, no FlareSolverr configured), `price_lookup` returns `{'error': 'Missing Token'}` and the caller raises `LibraryError`. The flow's EV fallback hits the same wall, then the generic "Invalid station ID" error displays. Users had no idea Cloudflare was the real cause (#232).
- Add a `CloudflareBlocked` exception. `validate_station` raises it when it detects the CSRF-missing failure mode, instead of falling through to the EV fallback or being mapped to `InvalidStation`.
- Catch `CloudflareBlocked` in all four flow handlers that call `validate_station` (manual, home, postal, station list), and set a distinct `cloudflare` error key.
- Add `cloudflare` translation to strings.json and en.json with the FlareSolverr remedy text.
- List `CSRFTokenMissing` explicitly in the except for consistency with `coordinator.py`.

## Test plan
- [x] `pytest -q` → 67 passed.

## Followups
fr.json / pt.json don't yet have a `cloudflare` entry — happy to add translations or leave for native speakers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of Cloudflare/CSRF request blocks
  * Added clearer error messaging when Cloudflare blocks station lookups
  * Users are now guided to configure FlareSolverr as a solution when encountering these blocks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->