### PR TITLE
chore: narrow _redact except to (TypeError, ValueError)

### DIFF
--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -53,7 +53,10 @@ def _redact(data: Any) -> str:
 
     try:
         return json.dumps(_redact_recursive(data), default=str)
-    except Exception:  # noqa: BLE001
+    except (TypeError, ValueError):
+        # json.dumps raises TypeError for non-serialisable objects and
+        # ValueError for circular references / NaN with allow_nan=False.
+        # Anything else is a real bug and should propagate.
         return str(_redact_recursive(data))
 
 

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -53,7 +53,7 @@ def _redact(data: Any) -> str:
 
     try:
         return json.dumps(_redact_recursive(data), default=str)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # json.dumps raises TypeError for non-serialisable objects and
         # ValueError for circular references / NaN with allow_nan=False.
         # Anything else is a real bug and should propagate.


### PR DESCRIPTION
## Summary
- `_redact` wraps `json.dumps` which only raises `TypeError` (non-serialisable) or `ValueError` (NaN / circular refs). The current `except Exception  # noqa: BLE001` would mask unrelated bugs in `_redact_recursive`. Narrow it.

## Test plan
- [x] `pytest -q` → 67 passed.

## Followup
The other `# noqa: BLE001` sites in config_flow.py / coordinator.py / services.py wrap py_gasbuddy calls and have a richer exception surface (LibraryError, APIError, CSRFTokenMissing, MissingSearchData, aiohttp.ClientError, asyncio.TimeoutError). Happy to tighten those in follow-up PRs once we agree on the contract.