### PR TITLE
chore: translate cloudflare error + complete fr/pt error strings

### DIFF
--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -5,8 +5,9 @@
         },
         "error": {
             "station_id": "ID de station invalide",
-            "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "no_results": "Aucune station trouvée dans cette zone.",
+            "invalid_url": "URL invalide.",
+            "cloudflare": "Impossible d'obtenir un jeton CSRF auprès de GasBuddy (Cloudflare bloque les requêtes). Configurez une URL FlareSolverr dans le champ optionnel et réessayez."
         },
         "step": {
             "user": {

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -5,8 +5,9 @@
         },
         "error": {
             "station_id": "ID de estação inválido",
-            "no_results": "No stations found in this area.",
-            "invalid_url": "Not a valid URL."
+            "no_results": "Nenhuma estação encontrada nesta área.",
+            "invalid_url": "URL inválida.",
+            "cloudflare": "Não foi possível obter um token CSRF do GasBuddy (Cloudflare está bloqueando as requisições). Configure uma URL FlareSolverr no campo opcional e tente novamente."
         },
         "step": {
             "user": {


### PR DESCRIPTION
## Summary
Follow-up to #259, which added the `cloudflare` error key to `en.json` and `strings.json` but left fr.json/pt.json without it.

- Add `cloudflare` translations to fr.json and pt.json.
- While here, translate `no_results` and `invalid_url` in both files (they were left in English).

Native speakers welcome to refine the wording.

## Test plan
- [x] Both files parse as valid JSON.
- [x] All four keys present in both files.