### PR TITLE
fix(config_flow): don't KeyError on retry after invalid station

### DIFF
--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -585,7 +585,11 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             user_input.setdefault(CONF_INTERVAL, 3600)
             user_input.setdefault(CONF_UOM, True)
             user_input.setdefault(CONF_GPS, True)
-            self._data.pop(CONF_POSTAL)
+            # Pop is idempotent — if the user lands here a second time
+            # (e.g. after picking an invalid station and being shown the
+            # form again), CONF_POSTAL is already gone and an
+            # unconditional .pop() would KeyError.
+            self._data.pop(CONF_POSTAL, None)
             self._data.update(user_input)
 
             # Get cached coordinates if available


### PR DESCRIPTION
## Summary
- `async_step_station_list` (line 588) does `self._data.pop(CONF_POSTAL)` unconditionally. If validation fails and the user is shown the form a second time, this raises `KeyError` on resubmit because the key is already gone — the user sees a generic flow crash instead of getting another try.
- Switch to `self._data.pop(CONF_POSTAL, None)` (idempotent).

## Test plan
- [x] `pytest -q` → 67 passed.
- Manual repro: search by postal → pick a bad station → resubmit. Today: KeyError. After: form re-rendered with the error message intact.