### PR TITLE
fix(config_flow): prevent duplicate station entries via unique_id

### DIFF
--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -411,6 +411,8 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ev_charging = validate["type"] == "ev"
                 else:
                     ev_charging = False
+                await self.async_set_unique_id(str(self._data[CONF_STATION_ID]))
+                self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=self._data[CONF_NAME],
                     data=self._data,
@@ -518,6 +520,8 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 ev_charging = False
 
+            await self.async_set_unique_id(str(self._data[CONF_STATION_ID]))
+            self._abort_if_unique_id_configured()
             return self.async_create_entry(
                 title=self._data[CONF_NAME],
                 data=self._data,
@@ -619,6 +623,8 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 ev_charging = False
 
+            await self.async_set_unique_id(str(self._data[CONF_STATION_ID]))
+            self._abort_if_unique_id_configured()
             return self.async_create_entry(
                 title=self._data[CONF_NAME],
                 data=self._data,

--- a/tests/test_ev_coverage.py
+++ b/tests/test_ev_coverage.py
@@ -593,6 +593,10 @@ async def test_config_flow_ev_charging_flag(hass):
     """Test ConfigFlow sets ev_charging to True when station ends with [EV]."""
     flow = GasBuddyFlowHandler()
     flow.hass = hass
+    # async_set_unique_id mutates self.context; when constructing the flow
+    # directly (not via the flow manager) the default context is a
+    # read-only mappingproxy, so replace it with a real dict.
+    flow.context = {}
     flow._station_list = {"208656": "Costco [EV]"}  # noqa: SLF001
     flow._data = {CONF_NAME: "Costco Station", CONF_STATION_ID: "208656"}  # noqa: SLF001
 


### PR DESCRIPTION
## Summary
- The integration never called `async_set_unique_id` / `_abort_if_unique_id_configured`, so a user could add the same station as separate config entries (via different flow paths or by re-running the same flow). Each one spawns its own coordinator → duplicate polling, duplicate sensors, confused user.
- Set `unique_id = str(station_id)` right before each `async_create_entry` in the three station-creating paths (`manual`, `home2`, `station_list`). HA aborts the second add cleanly with "already configured".

## Test plan
- [x] `pytest -q` → 67 passed.
- [x] Updated `test_config_flow_ev_charging_flag` to give the directly-constructed flow handler a real `context` dict (the new `async_set_unique_id` needs to mutate it; the default mappingproxy is read-only).