### PR TITLE
fix(coordinator): honor CONF_FETCH_GAS to skip price_lookup

### DIFF
--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -94,15 +94,14 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         ev_charging_enabled = self._config.options.get(CONF_EV_CHARGING, False)
         fetch_gas = self._config.options.get(CONF_FETCH_GAS, True)
 
-        if not fetch_gas:
+        if not fetch_gas:  # noqa: PLR1702
             # User has disabled gas-price polling on this station — most
             # commonly an EV-only station. Skip price_lookup entirely
             # (it would APIError every cycle) and bootstrap self._data
             # so the EV enrichment block below can populate sensors.
             if not ev_charging_enabled:
                 raise UpdateFailed(
-                    "Both gas price polling and EV charging are disabled — "
-                    "nothing to fetch."
+                    "Both gas price polling and EV charging are disabled — nothing to fetch."
                 )
             lat = self._config.data.get("latitude") or self.hass.config.latitude
             lon = self._config.data.get("longitude") or self.hass.config.longitude
@@ -178,7 +177,9 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                                     "latitude": matching["latitude"],
                                     "longitude": matching["longitude"],
                                 }
-                                self.hass.config_entries.async_update_entry(self._config, data=new_data)
+                                self.hass.config_entries.async_update_entry(
+                                    self._config, data=new_data
+                                )
                         else:
                             self._data = {
                                 "station_id": self._config.data[CONF_STATION_ID],

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     CONF_EV_CHARGING,
+    CONF_FETCH_GAS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_SOLVER,
@@ -91,84 +92,109 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Update data via library."""
         ev_charging_enabled = self._config.options.get(CONF_EV_CHARGING, False)
-        try:
-            self._data = await self._api.price_lookup()
-            _LOGGER.debug("Gas station data: %s", _redact(self._data))
+        fetch_gas = self._config.options.get(CONF_FETCH_GAS, True)
 
-            config_lat = self._config.data.get("latitude")
-            config_lon = self._config.data.get("longitude")
-            if config_lat is not None and config_lon is not None:
-                gas_lat = self._data.get("latitude")
-                gas_lon = self._data.get("longitude")
-                if gas_lat is not None and gas_lon is not None:
-                    if abs(gas_lat - config_lat) > 1.0 or abs(gas_lon - config_lon) > 1.0:
-                        raise APIError("Station ID collision detected")  # noqa: TRY301
-        except (APIError, LibraryError, CSRFTokenMissing) as ex:
-            if ev_charging_enabled:
-                _LOGGER.warning("Price lookup failed, trying EV station fallback: %s", ex)
-                try:
-                    # Use coordinates from config entry if available, otherwise home coordinates
-                    lat = self._config.data.get("latitude")
-                    lon = self._config.data.get("longitude")
-                    if lat is None:
-                        lat = self.hass.config.latitude
-                    if lon is None:
-                        lon = self.hass.config.longitude
-                    ev_res = await self._api.ev_stations_nearby(
-                        lat=lat,
-                        lon=lon,
-                        radius=100,
-                        limit=100,
-                    )
+        if not fetch_gas:
+            # User has disabled gas-price polling on this station — most
+            # commonly an EV-only station. Skip price_lookup entirely
+            # (it would APIError every cycle) and bootstrap self._data
+            # so the EV enrichment block below can populate sensors.
+            if not ev_charging_enabled:
+                raise UpdateFailed(
+                    "Both gas price polling and EV charging are disabled — "
+                    "nothing to fetch."
+                )
+            lat = self._config.data.get("latitude") or self.hass.config.latitude
+            lon = self._config.data.get("longitude") or self.hass.config.longitude
+            self._data = {
+                "station_id": self._config.data[CONF_STATION_ID],
+                "name": self._config.data.get(CONF_NAME, "EV Station"),
+                "latitude": lat,
+                "longitude": lon,
+            }
+            _LOGGER.debug(
+                "fetch_gas disabled — bootstrapping EV-only data: %s",
+                _redact(self._data),
+            )
+        else:
+            try:
+                self._data = await self._api.price_lookup()
+                _LOGGER.debug("Gas station data: %s", _redact(self._data))
 
-                    _LOGGER.debug("EV station fallback search result: %s", _redact(ev_res))
+                config_lat = self._config.data.get("latitude")
+                config_lon = self._config.data.get("longitude")
+                if config_lat is not None and config_lon is not None:
+                    gas_lat = self._data.get("latitude")
+                    gas_lon = self._data.get("longitude")
+                    if gas_lat is not None and gas_lon is not None:
+                        if abs(gas_lat - config_lat) > 1.0 or abs(gas_lon - config_lon) > 1.0:
+                            raise APIError("Station ID collision detected")  # noqa: TRY301
+            except (APIError, LibraryError, CSRFTokenMissing) as ex:
+                if ev_charging_enabled:
+                    _LOGGER.warning("Price lookup failed, trying EV station fallback: %s", ex)
+                    try:
+                        # Use coordinates from config entry if available, otherwise home coordinates
+                        lat = self._config.data.get("latitude")
+                        lon = self._config.data.get("longitude")
+                        if lat is None:
+                            lat = self.hass.config.latitude
+                        if lon is None:
+                            lon = self.hass.config.longitude
+                        ev_res = await self._api.ev_stations_nearby(
+                            lat=lat,
+                            lon=lon,
+                            radius=100,
+                            limit=100,
+                        )
 
-                    matching = next(
-                        (
-                            s
-                            for s in (ev_res or {}).get("stations", [])
-                            if s.get("station_id") is not None
-                            and str(s["station_id"]).strip()
-                            == str(self._config.data[CONF_STATION_ID]).strip()
-                        ),
-                        None,
-                    )
-                    if matching:
-                        self._data = {
-                            "station_id": matching["station_id"],
-                            "name": matching["name"],
-                            "latitude": matching["latitude"],
-                            "longitude": matching["longitude"],
-                            "unit_of_measure": "dollars_per_gallon",
-                            "currency": "USD",
-                        }
-                        # Update config entry if coordinates are new or changed
-                        if (
-                            self._config.data.get("latitude") != matching["latitude"]
-                            or self._config.data.get("longitude") != matching["longitude"]
-                        ):
-                            new_data = {
-                                **self._config.data,
+                        _LOGGER.debug("EV station fallback search result: %s", _redact(ev_res))
+
+                        matching = next(
+                            (
+                                s
+                                for s in (ev_res or {}).get("stations", [])
+                                if s.get("station_id") is not None
+                                and str(s["station_id"]).strip()
+                                == str(self._config.data[CONF_STATION_ID]).strip()
+                            ),
+                            None,
+                        )
+                        if matching:
+                            self._data = {
+                                "station_id": matching["station_id"],
+                                "name": matching["name"],
                                 "latitude": matching["latitude"],
                                 "longitude": matching["longitude"],
+                                "unit_of_measure": "dollars_per_gallon",
+                                "currency": "USD",
                             }
-                            self.hass.config_entries.async_update_entry(self._config, data=new_data)
-                    else:
-                        self._data = {
-                            "station_id": self._config.data[CONF_STATION_ID],
-                            "name": self._config.data.get(CONF_NAME, "EV Station"),
-                            "latitude": lat,
-                            "longitude": lon,
-                            "unit_of_measure": "dollars_per_gallon",
-                            "currency": "USD",
-                        }
-                except Exception as fallback_ex:  # noqa: BLE001
-                    _LOGGER.error("EV fallback failed: %s", fallback_ex)
+                            # Update config entry if coordinates are new or changed
+                            if (
+                                self._config.data.get("latitude") != matching["latitude"]
+                                or self._config.data.get("longitude") != matching["longitude"]
+                            ):
+                                new_data = {
+                                    **self._config.data,
+                                    "latitude": matching["latitude"],
+                                    "longitude": matching["longitude"],
+                                }
+                                self.hass.config_entries.async_update_entry(self._config, data=new_data)
+                        else:
+                            self._data = {
+                                "station_id": self._config.data[CONF_STATION_ID],
+                                "name": self._config.data.get(CONF_NAME, "EV Station"),
+                                "latitude": lat,
+                                "longitude": lon,
+                                "unit_of_measure": "dollars_per_gallon",
+                                "currency": "USD",
+                            }
+                    except Exception as fallback_ex:  # noqa: BLE001
+                        _LOGGER.error("EV fallback failed: %s", fallback_ex)
+                        raise UpdateFailed(f"Error retrieving data: {ex}") from ex
+                else:
                     raise UpdateFailed(f"Error retrieving data: {ex}") from ex
-            else:
-                raise UpdateFailed(f"Error retrieving data: {ex}") from ex
-        except Exception as exception:
-            raise UpdateFailed from exception
+            except Exception as exception:
+                raise UpdateFailed from exception
 
         # Query EV station details if enabled
         if ev_charging_enabled and "latitude" in self._data and "longitude" in self._data:

--- a/tests/test_ev_coverage.py
+++ b/tests/test_ev_coverage.py
@@ -15,6 +15,7 @@ from custom_components.gasbuddy.config_flow import (
 from custom_components.gasbuddy.const import (
     ATTR_POSTAL_CODE,
     CONF_EV_CHARGING,
+    CONF_FETCH_GAS,
     CONF_GPS,
     CONF_INTERVAL,
     CONF_NAME,
@@ -139,6 +140,63 @@ async def test_coordinator_fallback_ev_exception(hass):
     mock_api.price_lookup = AsyncMock(side_effect=APIError("Price lookup failed"))
     mock_api.ev_stations_nearby = AsyncMock(side_effect=Exception("EV lookup failed"))
     coordinator._api = mock_api  # noqa: SLF001
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()  # noqa: SLF001
+
+
+async def test_coordinator_skips_price_lookup_when_fetch_gas_disabled(hass):
+    """fetch_gas=False bypasses price_lookup and falls through to EV enrichment."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STATION_ID: "208656",
+            CONF_NAME: "EV Station",
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            "latitude": 33.45,
+            "longitude": -112.50,
+        },
+        options={CONF_EV_CHARGING: True, CONF_FETCH_GAS: False},
+    )
+    entry.add_to_hass(hass)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+
+    mock_api = MagicMock()
+    mock_api.price_lookup = AsyncMock(side_effect=AssertionError("must not be called"))
+    mock_api.ev_stations_nearby = AsyncMock(
+        return_value={
+            "stations": [
+                {
+                    "station_id": "208656",
+                    "name": "Costco EV",
+                    "level2_count": 2,
+                    "dc_fast_count": 4,
+                }
+            ]
+        }
+    )
+    coordinator._api = mock_api  # noqa: SLF001
+
+    data = await coordinator._async_update_data()  # noqa: SLF001
+    assert not mock_api.price_lookup.called
+    assert mock_api.ev_stations_nearby.called
+    assert data["station_id"] == "208656"
+    assert data["ev_level2"] == 2
+
+
+async def test_coordinator_raises_when_both_options_disabled(hass):
+    """fetch_gas=False AND ev_charging=False → UpdateFailed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STATION_ID: "208656",
+            CONF_NAME: "Nothing",
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+        },
+        options={CONF_EV_CHARGING: False, CONF_FETCH_GAS: False},
+    )
+    entry.add_to_hass(hass)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()  # noqa: SLF001


### PR DESCRIPTION
## Summary
- The coordinator unconditionally called `price_lookup` every cycle, even when the user had "Fetch Gas Prices" disabled. For an EV-only station this caused an `APIError`/`CSRFTokenMissing` on every poll, warning-level log noise, and an unnecessary CSRF round-trip — with the EV fallback path only entered as a side effect of that exception.
- Gate the price_lookup branch on `fetch_gas`. When disabled and `ev_charging` is enabled, bootstrap `self._data` with the station id/name/coords from the config entry so the existing EV enrichment block can run. When both options are off, raise `UpdateFailed` cleanly.

## Test plan
- [x] `pytest -q` → 69 passed (2 new tests), coverage 100%.
- New tests:
  - `test_coordinator_skips_price_lookup_when_fetch_gas_disabled` (price_lookup not called; ev_stations_nearby is)
  - `test_coordinator_raises_when_both_options_disabled` (UpdateFailed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gas price polling is now configurable and can be disabled for EV-only mode operation.

* **Bug Fixes**
  * Improved resilience when gas pricing data is unavailable; system automatically falls back to using EV charging station information.

* **Tests**
  * Added test coverage for EV-only operation mode and verification of system behavior when gas price fetching is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->