### PR TITLE
fix(coordinator): don't hardcode USD/gallon in EV fallback

### DIFF
--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -133,14 +133,24 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                         ),
                         None,
                     )
+                    # Preserve unit/currency from the last good poll where
+                    # possible — hardcoding USD/dollars_per_gallon mislabels
+                    # CAD stations and any future non-USD market.
+                    carried = {
+                        k: v
+                        for k, v in {
+                            "unit_of_measure": self._data.get("unit_of_measure"),
+                            "currency": self._data.get("currency"),
+                        }.items()
+                        if v is not None
+                    }
                     if matching:
                         self._data = {
                             "station_id": matching["station_id"],
                             "name": matching["name"],
                             "latitude": matching["latitude"],
                             "longitude": matching["longitude"],
-                            "unit_of_measure": "dollars_per_gallon",
-                            "currency": "USD",
+                            **carried,
                         }
                         # Update config entry if coordinates are new or changed
                         if (
@@ -159,8 +169,7 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                             "name": self._config.data.get(CONF_NAME, "EV Station"),
                             "latitude": lat,
                             "longitude": lon,
-                            "unit_of_measure": "dollars_per_gallon",
-                            "currency": "USD",
+                            **carried,
                         }
                 except Exception as fallback_ex:  # noqa: BLE001
                     _LOGGER.error("EV fallback failed: %s", fallback_ex)

--- a/tests/test_ev_coverage.py
+++ b/tests/test_ev_coverage.py
@@ -716,3 +716,79 @@ async def test_validate_station_id_collision(hass) -> None:
         assert isinstance(result, dict)
         assert result["type"] == "ev"
         assert result["latitude"] == 44.0
+
+
+async def test_coordinator_fallback_preserves_unit_and_currency(hass):
+    """EV fallback carries unit_of_measure/currency from the last good poll, not hardcoded USD/gallon."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STATION_ID: "208656",
+            CONF_NAME: "EV Station",
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+        },
+        options={CONF_EV_CHARGING: True},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    # Simulate a previous successful poll of a Canadian station.
+    coordinator._data = {"unit_of_measure": "cents_per_liter", "currency": "CAD"}  # noqa: SLF001
+
+    mock_api = MagicMock()
+    mock_api.price_lookup = AsyncMock(side_effect=APIError("Price lookup failed"))
+    mock_api.ev_stations_nearby = AsyncMock(
+        return_value={
+            "stations": [
+                {
+                    "station_id": "208656",
+                    "name": "Matching Costco EV",
+                    "latitude": 33.45,
+                    "longitude": -112.50,
+                }
+            ]
+        }
+    )
+    coordinator._api = mock_api  # noqa: SLF001
+
+    data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data["unit_of_measure"] == "cents_per_liter"
+    assert data["currency"] == "CAD"
+
+
+async def test_coordinator_fallback_omits_unit_when_unknown(hass):
+    """On the first poll (no prior data) the fallback omits unit/currency rather than guessing USD/gallon."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STATION_ID: "208656",
+            CONF_NAME: "EV Station",
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+        },
+        options={CONF_EV_CHARGING: True},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+
+    mock_api = MagicMock()
+    mock_api.price_lookup = AsyncMock(side_effect=APIError("Price lookup failed"))
+    mock_api.ev_stations_nearby = AsyncMock(
+        return_value={
+            "stations": [
+                {
+                    "station_id": "208656",
+                    "name": "Matching Costco EV",
+                    "latitude": 33.45,
+                    "longitude": -112.50,
+                }
+            ]
+        }
+    )
+    coordinator._api = mock_api  # noqa: SLF001
+
+    data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert "unit_of_measure" not in data
+    assert "currency" not in data


### PR DESCRIPTION
## Summary
- The EV fallback path overwrote `unit_of_measure` and `currency` with hardcoded `dollars_per_gallon` / `USD` on every cycle that price_lookup failed. For Canadian stations (cents_per_liter / CAD) and any future non-USD market, a transient CSRF blip would flip the displayed unit until the next good poll.
- Carry the previous `self._data` values forward when available; omit them on cold start. `native_unit_of_measurement` already handles `None` cleanly.

## Test plan
- [x] `pytest -q` → 67 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect currency and unit of measure labels for EV station entries in non-USD markets. The app now preserves existing market settings instead of defaulting to USD pricing.

* **Tests**
  * Added unit tests for EV station fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->