### PR TITLE
fix(config_flow): drop double-reload in reconfigure

### DIFF
--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -689,8 +689,11 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     options[CONF_EV_CHARGING] = False
                     options[CONF_FETCH_GAS] = True
 
+                # async_update_entry already triggers a reload via the
+                # update_listener registered in async_setup_entry; the
+                # previous `async_create_task(async_reload(...))` here
+                # was a second, untracked reload that raced the listener.
                 self.hass.config_entries.async_update_entry(entry, data=self._data, options=options)
-                self.hass.async_create_task(self.hass.config_entries.async_reload(entry.entry_id))
                 _LOGGER.debug("%s reconfigured.", DOMAIN)
                 return self.async_abort(reason="reconfigure_successful")
 


### PR DESCRIPTION
## Summary
- `async_update_entry` fires the `update_listener` registered in `async_setup_entry` → `async_reload`. The explicit `hass.async_create_task(async_reload(...))` immediately after was a second, untracked reload that raced the listener.
- The task reference wasn't kept, so under unusual GC timing the explicit reload could even drop before scheduling, but the listener-driven reload always ran.

## Test plan
- [x] `pytest -q` → 67 passed.
- Manual: reconfigure flow still completes and the entry reflects new options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition during component reconfiguration that could cause conflicts between concurrent reload operations. Configuration updates now execute more reliably without triggering redundant reload cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->