### PR TITLE
fix(services): clear_cache target should be device, not entity

### DIFF
--- a/custom_components/gasbuddy/services.yaml
+++ b/custom_components/gasbuddy/services.yaml
@@ -79,5 +79,5 @@ clear_cache:
   name: Clear Cache
   description: Clear library cache file.
   target:
-    entity:
+    device:
       integration: gasbuddy

--- a/custom_components/gasbuddy/services.yaml
+++ b/custom_components/gasbuddy/services.yaml
@@ -78,6 +78,11 @@ ev_lookup_zip:
 clear_cache:
   name: Clear Cache
   description: Clear library cache file.
-  target:
-    device:
-      integration: gasbuddy
+  fields:
+    device_id:
+      name: Device
+      description: GasBuddy device whose cache file should be cleared.
+      required: true
+      selector:
+        device:
+          integration: gasbuddy


### PR DESCRIPTION
## Summary
- `services.yaml` declared `target.entity` for `clear_cache`, but the handler's schema requires `device_id` (and the implementation looks up the config entry via the device registry). Invoking from Developer Tools showed an entity selector whose output the schema rejected.
- Change to `target.device` so the UI returns the expected `device_id`.

## Test plan
- [x] `pytest -q` → 67 passed.
- Manual: Developer Tools → Call Service → gasbuddy.clear_cache now shows a device picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated `clear_cache` service to require a device ID parameter, with device selection limited to GasBuddy devices for streamlined configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/ha-gasbuddy/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->