### PR TITLE
chore: ignore translation files in codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=hass,doubleclick,Lokal,limite,attributs
-          - --skip="./.*,*.csv,*.ambr"
           - --quiet-level=2
         exclude_types: [csv]
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -649,4 +649,5 @@ commands = [["mypy", "custom_components{/}gasbuddy"]]
 deps = ["-rrequirements_test.txt"]
 
 [tool.codespell]
-ignore-words-list = "hass,invalide,mesure,Lokal,doubleclick,GoIn,going"
+ignore-words-list = "hass,doubleclick,Lokal,GoIn,going"
+skip = "./.*,*.csv,*.ambr,*/translations/*"


### PR DESCRIPTION
## Proposed change

Exclude translation files under `custom_components/*/translations/*` from codespell checks. Translation files contain localized/foreign words (e.g., `attributs`, `limite`, `invalide`, `mesure`) that are not English, triggering false-positive codespell typo alerts. 

By ignoring the translations directory, we no longer need these specific words in the ignore words list. This PR cleans up the codespell options in both `pyproject.toml` and `.pre-commit-config.yaml` to unify them and delegate the configuration to `pyproject.toml`.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] - [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.