### PR TITLE
docs: add AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,162 @@
+# AGENTS.md
+
+A short orientation for AI coding agents (Claude, Codex, Copilot, etc.)
+working in this repo. For human contributor guidelines see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What this repo is
+
+A Home Assistant custom integration that surfaces gas-station prices
+(and optionally EV-charger details) for individual GasBuddy stations.
+It depends on [py-gasbuddy](https://github.com/firstof9/py-gasbuddy) for
+the upstream GraphQL client.
+
+```
+custom_components/gasbuddy/
+├── __init__.py        # async_setup_entry / async_unload_entry / migrate
+├── coordinator.py     # DataUpdateCoordinator wrapping py_gasbuddy
+├── config_flow.py     # ConfigFlow + OptionsFlow + reconfigure
+├── sensor.py          # SensorEntity definitions
+├── services.py        # 5 services: lookup_gps/zip, ev_lookup_*, clear_cache
+├── const.py           # CONF_* keys + SENSOR_TYPES catalog
+├── diagnostics.py     # Config-entry + device diagnostics
+├── strings.json       # English source + translation schema
+└── translations/      # en.json (mirror of strings), fr.json, pt.json
+```
+
+## Environment + toolchain
+
+- **Python**: target is 3.14 (`target-version = "py314"` in `pyproject.toml`).
+  CI runs against Python 3.14.2.
+- **Linting**: ruff via pre-commit, pinned to **v0.15.12** (see `.pre-commit-config.yaml`).
+  Install that exact version locally; newer ruff (0.15.14+) emits
+  `PLW0717` warnings that aren't real failures and aren't gated by CI.
+- **Formatting**: ruff format with `target-version = "py314"`. This means
+  PEP 758 parenthesis-free `except`: ruff will rewrite
+  `except (TypeError, ValueError):` to `except TypeError, ValueError:`.
+  That's valid Python 3.14 — don't fight it.
+- **Tests**: `pytest` + `pytest-homeassistant-custom-component`. The
+  full suite is ~67 tests, runs in 13–22 seconds.
+
+```bash
+uv venv --python 3.14
+uv pip install -r requirements_test.txt
+uv pip install 'ruff==0.15.12'
+.venv/bin/python -m pytest -q --no-header
+.venv/bin/ruff check custom_components/
+.venv/bin/ruff format --check custom_components/
+```
+
+## Architectural notes that won't be obvious from the code
+
+### CSRF token cache is shared
+
+`py_gasbuddy.GasBuddy` accepts a `cache_file` path. The coordinator,
+config-flow, and services must all use the **same** path — defined
+once as `CACHE_FILE_NAME` in `const.py`. Each module has a small
+`_cache_path(hass)` helper that returns `f"{hass.config.config_dir}/{CACHE_FILE_NAME}"`.
+
+If you construct a `GasBuddy` without passing `cache_file=`, py-gasbuddy
+falls back to `~/.cache/py_gasbuddy/token` and you'll re-fetch a CSRF
+token on every call — which is exactly what Cloudflare blocks on first
+install. Don't do that.
+
+### Config-flow → entry shape
+
+Three flows create a config entry: `manual`, `home2` (search by home
+coordinates), and `station_list` (search by postal). All three set
+`unique_id = str(station_id)` and call `_abort_if_unique_id_configured()`
+before `async_create_entry` to prevent duplicates.
+
+Stored in `entry.data`: `CONF_STATION_ID`, `CONF_NAME`, `CONF_SOLVER`,
+`CONF_TIMEOUT`, `latitude`, `longitude`.
+
+Stored in `entry.options`: `CONF_INTERVAL`, `CONF_UOM`, `CONF_GPS`,
+`CONF_EV_CHARGING`, `CONF_FETCH_GAS`. `CONFIG_VER` is bumped when this
+shape changes; see `async_migrate_entry`.
+
+### Coordinator's two-path update
+
+`_async_update_data` honors `CONF_FETCH_GAS`:
+
+- **If `fetch_gas=False`** (typically an EV-only station): bootstrap
+  `self._data` with the station id + config coordinates, then fall
+  through to the EV enrichment block. Don't call `price_lookup` — it
+  would `APIError` every poll for EV-only stations.
+- **If `fetch_gas=True`**: call `price_lookup`. On failure, if
+  `ev_charging` is also enabled, fall back to `ev_stations_nearby` to
+  resolve the station as an EV-only entry.
+
+When the EV-fallback path constructs synthetic data, **carry forward
+`unit_of_measure` and `currency` from the previous `self._data` rather
+than hardcoding USD/gallon** (Canadian stations report CAD/cents-per-liter).
+
+### Cloudflare-block detection
+
+When py-gasbuddy can't fetch a CSRF token (typically because Cloudflare
+is blocking and no FlareSolverr is configured), the GraphQL request
+fails with a content-less `LibraryError`. We can't tell that apart from
+"GasBuddy returned an error for this station ID" by inspecting the
+exception alone.
+
+Current workaround in `validate_station`: probe the client's
+`_cf_last` sentinel after the failed call. `is False` exactly when
+the CSRF round-trip failed. Once py-gasbuddy ships a public
+`CloudflareBlocked` exception (see firstof9/py-gasbuddy#258), switch
+to `except CloudflareBlocked`.
+
+### `_clear_cache` service
+
+Resolves the config entry via the device registry: prefer
+`device_entry.identifiers` (post `DeviceInfo.identifiers` migration);
+fall back to the legacy `connections` entry for devices registered by
+older versions; raise a clear `ValueError` if neither matches.
+
+### Test-mocking convention
+
+Tests typically mock the HTTP layer via `aioresponses` (the GraphQL
+POST and the CSRF GET). Tests that mock at the `GasBuddy.method`
+level — e.g. `patch("...GasBuddy.price_lookup", ...)` — exist and
+work, but **don't refactor a `price_lookup()` caller to use
+`process_request()` directly**: those tests will break. Either keep
+the existing call shape or update the tests.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ruff check` says `PLW0717: Try clause contains too many statements` | Local ruff is newer than the pre-commit pin (0.15.12) | Install ruff 0.15.12 explicitly |
+| Pre-commit complains about `except (X, Y):` formatting | Project targets py314 + PEP 758 | Let ruff format rewrite to `except X, Y:` |
+| `test_validate_station_*` fails with `AttributeError` after a refactor | Test mocks `GasBuddy.method` directly | Don't bypass the mocked method; or update the test mock |
+| HA setup stalls for ~minutes | `add_update_listener` not wrapped in `async_on_unload` | Wrap it; the listener accumulates across reloads |
+| Config-flow shows "Invalid station ID" but station is fine | Cloudflare is blocking the CSRF fetch | User needs FlareSolverr; surfaced as `CloudflareBlocked` → `cloudflare` error key |
+| Duplicate sensor entities for one station | Missing `async_set_unique_id` / `_abort_if_unique_id_configured` | Already in place for the three flow paths; don't bypass |
+| HA test env install fails | `pytest-homeassistant-custom-component==0.13.333` requires py 3.14 | Use `uv venv --python 3.14` |
+
+## When you change the public surface
+
+- **New sensor**: add an entry to `SENSOR_TYPES` in `const.py`. Sensor
+  appears automatically when the entry has the right options
+  (`CONF_EV_CHARGING` for `ev_*`, `CONF_FETCH_GAS` for fuel prices).
+- **New service**: register in `services.py` `async_register`, define
+  the handler, **and** add the entry to `services.yaml` and translation
+  files.
+- **New error key**: add to `strings.json`, then mirror in `en.json`,
+  `fr.json`, `pt.json`. CI doesn't enforce translation parity but the
+  user-facing experience suffers if you skip.
+- **Coordinator data shape change**: bump `CONFIG_VER` in `const.py`,
+  extend `async_migrate_entry`.
+
+## What to test
+
+A new behavior PR should land tests under `tests/`. Existing test
+files give good templates:
+
+- `test_config_flow.py` — flow-step tests via `hass.config_entries.flow.async_init`
+- `test_init.py` — setup / unload / migrate
+- `test_sensor.py` — sensor state and attribute assertions
+- `test_ev_coverage.py` — EV-charging-specific paths
+- `test_diagnostics.py` — diagnostics output snapshot
+
+Common helpers in `tests/common.py` + `tests/const.py`; HTTP fixtures
+under `tests/fixtures/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to ha-gasbuddy
+
+Thanks for considering a contribution! This integration depends on
+[py-gasbuddy](https://github.com/firstof9/py-gasbuddy) for the upstream
+GraphQL client — bug fixes that affect the GasBuddy API itself usually
+land there first, then this repo bumps the dependency.
+
+> AI coding agents: also read [AGENTS.md](AGENTS.md), which covers
+> repo-specific conventions in more detail than this file.
+
+## Getting started
+
+```bash
+git clone https://github.com/firstof9/ha-gasbuddy
+cd ha-gasbuddy
+
+# Python 3.14 is required (matches the integration's target + CI)
+uv venv --python 3.14
+source .venv/bin/activate
+uv pip install -r requirements_test.txt
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+## Running tests
+
+```bash
+# Full suite (~15s)
+pytest -q
+
+# Single test
+pytest tests/test_config_flow.py::test_form_manual_renders -v
+
+# With coverage report
+pytest --cov=custom_components/gasbuddy --cov-report=term-missing
+```
+
+CI enforces 80% coverage; the suite currently runs at 100%. Try to
+keep it there when adding new code paths.
+
+## Linting + formatting
+
+```bash
+pre-commit run --all-files
+```
+
+The project uses **ruff 0.15.12** (pinned in `.pre-commit-config.yaml`).
+If you've installed a newer ruff system-wide, install the pinned
+version into your venv:
+
+```bash
+uv pip install 'ruff==0.15.12'
+```
+
+Newer ruff versions emit `PLW0717` warnings against existing code that
+CI doesn't check — they're noise, not actionable.
+
+### Python 3.14 syntax
+
+The project targets Python 3.14 (`target-version = "py314"`). Ruff
+format applies PEP 758 parenthesis-free `except` clauses:
+
+```python
+# What you might write:
+except (TypeError, ValueError):
+    ...
+
+# What ruff format rewrites it to:
+except TypeError, ValueError:
+    ...
+```
+
+Both are valid Python 3.14. Don't fight the reformat.
+
+## Pull requests
+
+1. **Branch from `main`** (`git checkout -b fix/short-description`).
+2. **Keep PRs small and focused.** One bug or one feature per PR. Big
+   "polish bundles" are harder to review and revert.
+3. **Run the full suite + pre-commit before pushing.** CI runs both.
+4. **Add tests** for new behavior. Existing test files give good
+   templates — see `tests/test_config_flow.py` for flow tests and
+   `tests/test_ev_coverage.py` for coordinator/EV paths.
+5. **Update translations** if you add a new user-facing string. The
+   source is `strings.json`; mirror keys into `translations/en.json`,
+   `translations/fr.json`, and `translations/pt.json`.
+6. **Bump `CONFIG_VER`** in `const.py` if you change the config-entry
+   data/options shape, and extend `async_migrate_entry` so existing
+   users don't lose their config.
+7. **Reference the issue** if there is one (`Fixes #232`).
+
+## Translations
+
+`strings.json` is the source of truth. Translations live under
+`translations/`:
+
+- `en.json` — mirror of `strings.json`
+- `fr.json` — French (community-maintained)
+- `pt.json` — Portuguese (community-maintained)
+
+When you add a new key, add it to `strings.json` and `en.json` at
+minimum. Native-speaker contributions for `fr.json` / `pt.json` are
+welcome.
+
+## Reporting bugs
+
+Use the [issue tracker](https://github.com/firstof9/ha-gasbuddy/issues).
+Useful information:
+
+- Home Assistant version
+- ha-gasbuddy version (from HACS or `manifest.json`)
+- py-gasbuddy version (from HA logs at startup)
+- Whether you're using FlareSolverr, and if so the version
+- Relevant log lines (set `gasbuddy` to debug under `logger:` in
+  `configuration.yaml`)
+
+## Releases
+
+The maintainer publishes releases via GitHub Releases. The manifest's
+`"version": "0.0.0-dev"` is rewritten by the release pipeline.
+
+## License
+
+By contributing you agree your changes are licensed under the
+project's existing license (see `LICENSE`).


### PR DESCRIPTION
## Summary
Adds two docs to capture conventions I had to figure out the hard way over the last batch of PRs. The README references "Contribution guidelines" but no CONTRIBUTING.md exists yet.

- **CONTRIBUTING.md** — human-facing: env setup, test running, translation conventions, PR checklist, release flow.
- **AGENTS.md** — short orientation for AI coding agents (Claude / Codex / Copilot). Covers the same conventions plus the tribal-knowledge bits that aren't obvious from the code:
  - Python 3.14 target + PEP 758 `except` formatting (ruff rewrites the tuple form)
  - Ruff 0.15.12 pin — newer versions emit noise PLW0717
  - CSRF cache file path convention (`CACHE_FILE_NAME`), shared across coordinator/config_flow/services
  - Coordinator two-path update with `CONF_FETCH_GAS`
  - EV-fallback currency-carry rule (don't hardcode USD/gallon)
  - CloudflareBlocked detection pattern + the py-gasbuddy followup that will let us drop the private-attribute probe
  - Test-mocking convention (HTTP-level via aioresponses, not method-level)
  - Common pitfalls table mapping symptoms → causes

Feel free to push back on anything that misrepresents the project's actual conventions — these are based on what I observed across recent PRs, not on a project-policy doc that doesn't exist yet.

## Test plan
- [x] Files render correctly in GitHub's markdown preview
- No code changes, so existing tests remain at 67/67 passing