### PR TITLE
docs: sync AGENTS.md and CONTRIBUTING.md with current main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,20 +28,22 @@ custom_components/gasbuddy/
 
 - **Python**: target is 3.14 (`target-version = "py314"` in `pyproject.toml`).
   CI runs against Python 3.14.2.
-- **Linting**: ruff via pre-commit, pinned to **v0.15.12** (see `.pre-commit-config.yaml`).
-  Install that exact version locally; newer ruff (0.15.14+) emits
-  `PLW0717` warnings that aren't real failures and aren't gated by CI.
+- **Linting**: ruff via pre-commit, pinned to **v0.15.14** (see `.pre-commit-config.yaml`).
+  Install that exact version locally. `pyproject.toml` ignores `PLW0717`,
+  a rule selector that only exists in ruff 0.15.14+; an older ruff (e.g.
+  0.15.12) fails to even parse the config with `Unknown rule selector:
+  PLW0717`.
 - **Formatting**: ruff format with `target-version = "py314"`. This means
   PEP 758 parenthesis-free `except`: ruff will rewrite
   `except (TypeError, ValueError):` to `except TypeError, ValueError:`.
   That's valid Python 3.14 — don't fight it.
 - **Tests**: `pytest` + `pytest-homeassistant-custom-component`. The
-  full suite is ~67 tests, runs in 13–22 seconds.
+  full suite is ~99 tests, runs in 15–25 seconds.
 
 ```bash
 uv venv --python 3.14
 uv pip install -r requirements_test.txt
-uv pip install 'ruff==0.15.12'
+uv pip install 'ruff==0.15.14'
 .venv/bin/python -m pytest -q --no-header
 .venv/bin/ruff check custom_components/
 .venv/bin/ruff format --check custom_components/
@@ -107,10 +109,10 @@ to `except CloudflareBlocked`.
 
 ### `_clear_cache` service
 
-Resolves the config entry via the device registry: prefer
-`device_entry.identifiers` (post `DeviceInfo.identifiers` migration);
-fall back to the legacy `connections` entry for devices registered by
-older versions; raise a clear `ValueError` if neither matches.
+Resolves the config entry from the device registry via
+`next(iter(device_entry.config_entries), None)`, then looks the
+coordinator up in `hass.data[DOMAIN]`. Raises a clear `ValueError` if
+the device isn't found or maps to no gasbuddy config entry.
 
 ### Test-mocking convention
 
@@ -125,7 +127,7 @@ the existing call shape or update the tests.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `ruff check` says `PLW0717: Try clause contains too many statements` | Local ruff is newer than the pre-commit pin (0.15.12) | Install ruff 0.15.12 explicitly |
+| `ruff` says `Unknown rule selector: PLW0717` and won't run | Local ruff is older than the pre-commit pin (0.15.14); `PLW0717` doesn't exist in it | Install ruff 0.15.14 explicitly |
 | Pre-commit complains about `except (X, Y):` formatting | Project targets py314 + PEP 758 | Let ruff format rewrite to `except X, Y:` |
 | `test_validate_station_*` fails with `AttributeError` after a refactor | Test mocks `GasBuddy.method` directly | Don't bypass the mocked method; or update the test mock |
 | HA setup stalls for ~minutes | `add_update_listener` not wrapped in `async_on_unload` | Wrap it; the listener accumulates across reloads |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,16 +45,17 @@ keep it there when adding new code paths.
 pre-commit run --all-files
 ```
 
-The project uses **ruff 0.15.12** (pinned in `.pre-commit-config.yaml`).
-If you've installed a newer ruff system-wide, install the pinned
+The project uses **ruff 0.15.14** (pinned in `.pre-commit-config.yaml`).
+If you've installed a different ruff system-wide, install the pinned
 version into your venv:
 
 ```bash
-uv pip install 'ruff==0.15.12'
+uv pip install 'ruff==0.15.14'
 ```
 
-Newer ruff versions emit `PLW0717` warnings against existing code that
-CI doesn't check — they're noise, not actionable.
+`pyproject.toml` ignores the `PLW0717` rule, which only exists in ruff
+0.15.14+. An older ruff (such as 0.15.12) refuses to run at all with
+`Unknown rule selector: PLW0717`, so match the pinned version.
 
 ### Python 3.14 syntax
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Sync `AGENTS.md` and `CONTRIBUTING.md` with the current state of `main`. Three things drifted:

- **ruff pin.** Both docs say the project pins ruff **0.15.12**, but `.pre-commit-config.yaml` now pins **0.15.14** and `pyproject.toml` ignores `PLW0717` (a selector that only exists in 0.15.14+). With an older ruff the config doesn't even parse: `Unknown rule selector: PLW0717`. The old docs had this backwards (they called 0.15.14 "noise"), which actively steers a contributor to install a ruff that can't run. Updated the version, the install command, and the AGENTS.md pitfall-table row.
- **`_clear_cache`.** The deal-price-sensors feature replaced the device-registry lookup with `next(iter(device_entry.config_entries), None)`. The AGENTS.md description still documented the older `identifiers`/`connections` parsing. Updated it to match the code.
- **Test count.** Bumped the documented suite size from ~67 to ~99.

Docs only; no code paths change.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [ ] Tests have been added to verify that the new code works. <!-- N/A: documentation-only change -->
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in `README.md` <!-- N/A: no user-facing config change -->

If the code communicates with devices, web services, or third-party tools:

- [ ] The `manifest.json` file has all fields filled out correctly. <!-- N/A -->
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description. <!-- N/A -->
