### PR TITLE
fix: advance config-entry version during migration without data changes

### DIFF
--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -108,7 +108,9 @@ async def async_migrate_entry(hass, config_entry) -> bool:
         if CONF_TIMEOUT not in updated_config:
             updated_config[CONF_TIMEOUT] = 60000
 
-    if updated_config != config_entry.data:
+    # Persist the bumped version even when no data keys changed; otherwise
+    # the entry stays on the old version and HA re-runs migration every start.
+    if updated_config != config_entry.data or config_entry.version != new_version:
         hass.config_entries.async_update_entry(
             config_entry, data=updated_config, version=new_version
         )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -112,6 +112,22 @@ async def test_migrate_entry(hass, mock_gasbuddy):
     assert entry.data[CONF_SOLVER] is None
 
 
+async def test_migrate_entry_advances_version_without_data_change(hass, mock_gasbuddy):
+    """Migration must advance the version even when no data keys need adding.
+
+    CONFIG_DATA already contains every key the migration steps would add, so
+    the data dict is unchanged. The entry version still has to move to
+    CONFIG_VER, otherwise HA re-runs the migration on every startup.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, title="gas_station", data=CONFIG_DATA, version=2)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == CONFIG_VER
+
+
 async def test_remove_config_entry_device(hass, integration):
     """Test async_remove_config_entry_device."""
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`async_migrate_entry` bumps the config-entry version by calling
`async_update_entry(..., version=new_version)` — but only inside
`if updated_config != config_entry.data:`. So when a pre-`CONFIG_VER`
entry already contains every key the migration steps would add (for
example a version-2 entry that already has `CONF_GPS`, `CONF_SOLVER`,
and `CONF_TIMEOUT`), `updated_config == config_entry.data`, the
`async_update_entry` call is skipped, and the entry's `version` is never
advanced. `async_migrate_entry` still returns `True`, so HA treats the
load as successful but re-runs the migration on every startup.

Fix: persist the version whenever it is behind `CONFIG_VER`, regardless
of whether any data keys changed.

Adds a regression test (`test_migrate_entry_advances_version_without_data_change`)
that sets up a version-2 entry whose data already has all the keys and
asserts the version reaches `CONFIG_VER`. It fails before this change and
passes after.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in `README.md` <!-- N/A: no user-facing change -->

If the code communicates with devices, web services, or third-party tools:

- [ ] The `manifest.json` file has all fields filled out correctly. <!-- N/A -->
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description. <!-- N/A -->
