### PR TITLE
docs: document the cheapest gas tracker in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,28 @@ Configuration is done via the Home Assistant UI. When adding the integration, yo
 *   **Manual**: Enter the GasBuddy Station ID directly.
 *   **Search by Home**: Uses your Home Assistant zone coordinates to find nearby stations.
 *   **Search by Postal Code**: Enter a specific Zip or Postal Code to find stations in that area.
+*   **Track Cheapest Nearby Gas**: Instead of a fixed station, follow whichever nearby station is currently cheapest for a fuel type and price type you choose (see [Cheapest gas tracker](#cheapest-gas-tracker)).
 
 You can configure the following options by clicking **Configure** on the integration card:
 *   **Polling interval**: Polling frequency in seconds.
 *   **Show per liter/gallon in unit of measure**: Standardizes price representation.
 *   **Show stations on map**: Enables rendering of stations on the Map panel.
 *   **Enable EV charging sensors**: Toggles dedicated EV charging sensors that report connector counts and charging power per connector type. Entity IDs depend on the station name you configure; the sensor keys created include `ev_level1`, `ev_level2`, `ev_dc_fast`, `ev_j1772` (+ `_power`), `ev_ccs` (+ `_power`), `ev_chademo` (+ `_power`), `ev_nacs` (+ `_power`), and `ev_status`.
+
+### Cheapest gas tracker
+
+The **Track Cheapest Nearby Gas** option creates an entry that follows the lowest-priced nearby station rather than a single fixed station. On every refresh it re-checks and updates to whichever nearby station is currently cheapest, so the sensor always reflects the best nearby price.
+
+When you add it, choose:
+
+*   **Fuel type**: Regular, Midgrade, Premium, Diesel, E85, or UNL88.
+*   **Price type**:
+    *   **Best**: the lowest of the available credit, cash, and deal prices.
+    *   **Credit**: the standard posted (credit) price.
+    *   **Cash**: the cash price.
+    *   **Deal/GasBuddy Pay**: the GasBuddy Pay / deal price.
+
+Leave the postal code blank to search around your Home Assistant home coordinates, or enter a specific Zip/Postal Code to track the cheapest station in that area.
 
 ## Services
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The deal-price-sensors feature added a **Track Cheapest Nearby Gas** option to the add-integration flow (a tracker that follows whichever nearby station is currently cheapest, for a chosen fuel type and price type, re-checked on every refresh). The README didn't mention it, so users have no way to discover the feature from the docs.

This adds:

- A fourth bullet to the search-options list linking to the new section.
- A short **Cheapest gas tracker** section documenting the fuel types (`FUEL_KEY_CHOICES`) and the price types (`PRICE_TYPE_CHOICES`: Best / Credit / Cash / Deal), and noting it searches by home coordinates or a postal code.

Docs only; no code changes. The wording matches the current flow strings and `const.py` choices.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [ ] Tests have been added to verify that the new code works. <!-- N/A: documentation-only change -->
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in `README.md`

If the code communicates with devices, web services, or third-party tools:

- [ ] The `manifest.json` file has all fields filled out correctly. <!-- N/A -->
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description. <!-- N/A -->
