### PR TITLE
feat: add brand and station filters to cheapest nearby mode (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ When you add it, choose:
 
 Leave the postal code blank to search around your Home Assistant home coordinates, or enter a specific Zip/Postal Code to track the cheapest station in that area.
 
+You can optionally configure inclusion and exclusion filters to restrict tracking to specific brands or stations.
+
 ## Sensors
 
 The integration provides a variety of sensors depending on your configuration options and the capabilities of the tracked station. Sensors are categorized into three groups:

--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -11,8 +11,12 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_EV_CHARGING,
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
     CONF_GPS,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
     CONF_INTERVAL,
     CONF_SOLVER,
     CONF_TIMEOUT,
@@ -110,6 +114,16 @@ async def async_migrate_entry(hass, config_entry) -> bool:
     if version < 7:
         if CONF_TIMEOUT not in updated_config:
             updated_config[CONF_TIMEOUT] = 60000
+
+    if version < 8:
+        for key in (
+            CONF_EXCLUDE_BRANDS,
+            CONF_INCLUDE_BRANDS,
+            CONF_EXCLUDE_STATIONS,
+            CONF_INCLUDE_STATIONS,
+        ):
+            if key not in updated_config:
+                updated_config[key] = []
 
     # Persist the bumped version even when no data keys changed; otherwise
     # the entry stays on the old version and HA re-runs migration every start.

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -22,9 +22,13 @@ from .const import (
     CACHE_FILE_NAME,
     CONF_CHEAPEST,
     CONF_EV_CHARGING,
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
     CONF_FUEL_KEY,
     CONF_GPS,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_POSTAL,
@@ -294,6 +298,58 @@ async def _get_station_list(  # noqa: PLR0914
     return stations_list
 
 
+async def _get_nearby_brands_and_stations(
+    hass: HomeAssistant,
+    postal: str | None,
+    solver: str | None,
+    timeout: int,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Fetch nearby stations and return unique brands and stations dicts."""
+    lat = None
+    lon = None
+    if not postal:
+        lat = hass.config.latitude
+        lon = hass.config.longitude
+
+    gb = py_gasbuddy.GasBuddy(
+        solver_url=solver,
+        cache_file=_cache_path(hass),
+        timeout=timeout,
+        session=async_get_clientsession(hass),
+    )
+    try:
+        result = await gb.price_lookup_service(lat=lat, lon=lon, zipcode=postal, limit=20)
+    except CSRFTokenMissing as ex:
+        raise CloudflareBlocked from ex
+    except (APIError, LibraryError) as ex:
+        if _csrf_blocked_via_state(gb):
+            raise CloudflareBlocked from ex
+        _LOGGER.warning("Error fetching nearby stations for filtering: %s", ex)
+        return {}, {}
+    except Exception as ex:  # noqa: BLE001
+        _LOGGER.warning("Unexpected error fetching nearby stations for filtering: %s", ex)
+        return {}, {}
+
+    brands = {}
+    stations = {}
+    for station in result.get("results") or []:
+        station_id = station.get("station_id") or station.get("id")
+        if not station_id:
+            continue
+        station_id = str(station_id)
+        addr = (station.get("address") or {}).get("line1", "")
+        name = station.get("name", "Unknown")
+        stations[station_id] = f"{name} ({addr})" if addr else name
+
+        for brand in station.get("brands", []):
+            brand_id = brand.get("brandId")
+            brand_name = brand.get("name")
+            if brand_id and brand_name:
+                brands[str(brand_id)] = str(brand_name)
+
+    return brands, stations
+
+
 def _get_schema_manual(  # pylint: disable-next=unused-argument
     hass: Any, user_input: dict[str, Any], default_dict: dict[str, Any]
 ) -> Any:
@@ -429,6 +485,64 @@ def _get_schema_cheapest(  # pylint: disable-next=unused-argument
         ),
         vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT, DEFAULT_TIMEOUT)): vol.All(
             cv.positive_int, vol.Range(min=1000, max=300000)
+        ),
+    })
+
+
+def _get_schema_cheapest_filters(
+    hass: Any,
+    brands: dict[str, str],
+    stations: dict[str, str],
+    user_input: dict[str, Any] | None,
+    default_dict: dict[str, Any],
+) -> Any:
+    """Get a schema for Cheapest Gas brand and station filters."""
+    if user_input is None:
+        user_input = {}
+
+    def _get_default(key: str, fallback_default: Any = None) -> Any | None:
+        """Get default value for key."""
+        return user_input.get(key, default_dict.get(key, fallback_default))
+
+    brand_options = [{"value": k, "label": v} for k, v in brands.items()]
+    station_options = [{"value": k, "label": v} for k, v in stations.items()]
+
+    return vol.Schema({
+        vol.Optional(
+            CONF_EXCLUDE_BRANDS, default=_get_default(CONF_EXCLUDE_BRANDS, [])
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=brand_options,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(
+            CONF_INCLUDE_BRANDS, default=_get_default(CONF_INCLUDE_BRANDS, [])
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=brand_options,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(
+            CONF_EXCLUDE_STATIONS, default=_get_default(CONF_EXCLUDE_STATIONS, [])
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=station_options,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(
+            CONF_INCLUDE_STATIONS, default=_get_default(CONF_INCLUDE_STATIONS, [])
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=station_options,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
         ),
     })
 
@@ -759,7 +873,7 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     # Cheapest Nearby Gas
     async def async_step_cheapest(self, user_input=None):
-        """Handle the cheapest gas tracker flow."""
+        """Handle the cheapest gas tracker flow (Step 1)."""
         self._errors = {}
 
         if user_input is not None:
@@ -785,6 +899,30 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self._show_config_cheapest(user_input)
                 data[CONF_POSTAL] = postal
 
+            self._data.update(data)
+            return await self.async_step_cheapest_filters()
+        return await self._show_config_cheapest(user_input)
+
+    async def async_step_cheapest_filters(self, user_input=None):
+        """Handle Step 2: Brand/station filters for cheapest gas tracker."""
+        self._errors = {}
+
+        if user_input is not None:
+            data: dict[str, Any] = {
+                CONF_NAME: self._data[CONF_NAME],
+                CONF_CHEAPEST: True,
+                CONF_FUEL_KEY: self._data[CONF_FUEL_KEY],
+                CONF_PRICE_TYPE: self._data[CONF_PRICE_TYPE],
+                CONF_SOLVER: self._data.get(CONF_SOLVER),
+                CONF_TIMEOUT: self._data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                CONF_EXCLUDE_BRANDS: user_input.get(CONF_EXCLUDE_BRANDS, []),
+                CONF_INCLUDE_BRANDS: user_input.get(CONF_INCLUDE_BRANDS, []),
+                CONF_EXCLUDE_STATIONS: user_input.get(CONF_EXCLUDE_STATIONS, []),
+                CONF_INCLUDE_STATIONS: user_input.get(CONF_INCLUDE_STATIONS, []),
+            }
+            if CONF_POSTAL in self._data:
+                data[CONF_POSTAL] = self._data[CONF_POSTAL]
+
             return self.async_create_entry(
                 title=data[CONF_NAME],
                 data=data,
@@ -796,7 +934,25 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_FETCH_GAS: True,
                 },
             )
-        return await self._show_config_cheapest(user_input)
+
+        try:
+            brands, stations = await _get_nearby_brands_and_stations(
+                self.hass,
+                self._data.get(CONF_POSTAL),
+                self._data.get(CONF_SOLVER),
+                self._data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            )
+        except CloudflareBlocked:
+            self._errors[CONF_SOLVER] = "cloudflare"
+            return await self._show_config_cheapest(self._data)
+
+        return self.async_show_form(
+            step_id="cheapest_filters",
+            data_schema=_get_schema_cheapest_filters(
+                self.hass, brands, stations, user_input, self._data
+            ),
+            errors=self._errors,
+        )
 
     async def _show_config_cheapest(self, user_input):
         """Show the cheapest gas tracker configuration form."""
@@ -875,7 +1031,7 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self._show_reconfig_form(user_input)
 
     async def _async_step_reconfigure_cheapest(self, entry, user_input):
-        """Handle reconfigure for a cheapest gas tracker entry."""
+        """Handle reconfigure for a cheapest gas tracker entry (Step 1)."""
         if user_input is not None:
             solver = (user_input.get(CONF_SOLVER) or "").strip() or None
             if solver:
@@ -901,15 +1057,49 @@ class GasBuddyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 new_data.pop(CONF_POSTAL, None)
 
-            # async_update_entry already reloads via the update_listener;
-            # a second explicit reload here would race it (see above).
+            self._data = new_data
+            return await self.async_step_reconfigure_cheapest_filters()
+
+        return await self._show_reconfig_cheapest_form(user_input)
+
+    async def async_step_reconfigure_cheapest_filters(self, user_input=None):
+        """Handle Step 2 filters for cheapest gas tracker reconfiguration."""
+        entry = self._get_reconfigure_entry()
+        self._errors = {}
+
+        if user_input is not None:
+            new_data: dict[str, Any] = {
+                **self._data,
+                CONF_EXCLUDE_BRANDS: user_input.get(CONF_EXCLUDE_BRANDS, []),
+                CONF_INCLUDE_BRANDS: user_input.get(CONF_INCLUDE_BRANDS, []),
+                CONF_EXCLUDE_STATIONS: user_input.get(CONF_EXCLUDE_STATIONS, []),
+                CONF_INCLUDE_STATIONS: user_input.get(CONF_INCLUDE_STATIONS, []),
+            }
+
             self.hass.config_entries.async_update_entry(
                 entry, title=new_data[CONF_NAME], data=new_data
             )
             _LOGGER.debug("%s cheapest entry reconfigured.", DOMAIN)
             return self.async_abort(reason="reconfigure_successful")
 
-        return await self._show_reconfig_cheapest_form(user_input)
+        try:
+            brands, stations = await _get_nearby_brands_and_stations(
+                self.hass,
+                self._data.get(CONF_POSTAL),
+                self._data.get(CONF_SOLVER),
+                self._data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            )
+        except CloudflareBlocked:
+            self._errors[CONF_SOLVER] = "cloudflare"
+            return await self._show_reconfig_cheapest_form(self._data)
+
+        return self.async_show_form(
+            step_id="reconfigure_cheapest_filters",
+            data_schema=_get_schema_cheapest_filters(
+                self.hass, brands, stations, user_input, self._data
+            ),
+            errors=self._errors,
+        )
 
     async def _show_reconfig_cheapest_form(self, user_input):
         """Show the cheapest reconfigure form pre-filled with current entry data."""

--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -22,10 +22,14 @@ CONF_FETCH_GAS = "fetch_gas"
 CONF_CHEAPEST = "cheapest"
 CONF_FUEL_KEY = "fuel_key"
 CONF_PRICE_TYPE = "price_type"
+CONF_EXCLUDE_BRANDS = "exclude_brands"
+CONF_INCLUDE_BRANDS = "include_brands"
+CONF_EXCLUDE_STATIONS = "exclude_stations"
+CONF_INCLUDE_STATIONS = "include_stations"
 DEFAULT_INTERVAL = 3600
 DEFAULT_NAME = "Gas Station"
 DEFAULT_TIMEOUT = 60000
-CONFIG_VER = 7
+CONFIG_VER = 8
 
 # CSRF token cache, shared across the coordinator, config flow, and services
 # so they all benefit from a single fetched token (and don't each hammer the

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -21,8 +21,12 @@ from .const import (
     CACHE_FILE_NAME,
     CONF_CHEAPEST,
     CONF_EV_CHARGING,
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
     CONF_FUEL_KEY,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_POSTAL,
@@ -293,7 +297,7 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Final coordinator data: %s", _redact(self._data))
         return self._data
 
-    async def _async_update_cheapest(self) -> dict:
+    async def _async_update_cheapest(self) -> dict:  # noqa: PLR0914
         """Find and return the cheapest nearby station for the configured fuel and price type."""
         fuel_key = self._config.data.get(CONF_FUEL_KEY, "regular_gas")
         price_type = self._config.data.get(CONF_PRICE_TYPE, "best")
@@ -320,6 +324,33 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         stations = [s for s in (result.get("results") or []) if s.get(fuel_key)]
         if not stations:
             raise UpdateFailed("No stations with prices found for selected fuel")
+
+        exclude_brands = self._config.data.get(CONF_EXCLUDE_BRANDS) or []
+        include_brands = self._config.data.get(CONF_INCLUDE_BRANDS) or []
+        exclude_stations = self._config.data.get(CONF_EXCLUDE_STATIONS) or []
+        include_stations = self._config.data.get(CONF_INCLUDE_STATIONS) or []
+
+        filtered_stations = []
+        for s in stations:
+            station_id = str(s.get("station_id") or s.get("id") or "")
+            station_brand_ids = [
+                str(b.get("brandId")) for b in s.get("brands", []) if b.get("brandId")
+            ]
+
+            if exclude_stations and station_id in exclude_stations:
+                continue
+            if include_stations and station_id not in include_stations:
+                continue
+            if exclude_brands and any(b_id in exclude_brands for b_id in station_brand_ids):
+                continue
+            if include_brands and not any(b_id in include_brands for b_id in station_brand_ids):
+                continue
+
+            filtered_stations.append(s)
+
+        stations = filtered_stations
+        if not stations:
+            raise UpdateFailed("No stations with prices found for selected fuel after filtering")
 
         def _sort_key(s: dict) -> float:
             node = s.get(fuel_key) or {}

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -78,6 +78,24 @@
                     "fuel_key": "Fuel type",
                     "price_type": "Price type"
                 }
+            },
+            "cheapest_filters": {
+                "description": "Configure brand and station filters to restrict which stations are tracked.",
+                "data": {
+                    "exclude_brands": "Excluded Brands",
+                    "include_brands": "Included Brands",
+                    "exclude_stations": "Excluded Stations",
+                    "include_stations": "Included Stations"
+                }
+            },
+            "reconfigure_cheapest_filters": {
+                "description": "Configure brand and station filters to restrict which stations are tracked.",
+                "data": {
+                    "exclude_brands": "Excluded Brands",
+                    "include_brands": "Included Brands",
+                    "exclude_stations": "Excluded Stations",
+                    "include_stations": "Included Stations"
+                }
             }
         }
     },

--- a/custom_components/gasbuddy/translations/en.json
+++ b/custom_components/gasbuddy/translations/en.json
@@ -78,6 +78,24 @@
                     "fuel_key": "Fuel type",
                     "price_type": "Price type"
                 }
+            },
+            "cheapest_filters": {
+                "description": "Configure brand and station filters to restrict which stations are tracked.",
+                "data": {
+                    "exclude_brands": "Excluded Brands",
+                    "include_brands": "Included Brands",
+                    "exclude_stations": "Excluded Stations",
+                    "include_stations": "Included Stations"
+                }
+            },
+            "reconfigure_cheapest_filters": {
+                "description": "Configure brand and station filters to restrict which stations are tracked.",
+                "data": {
+                    "exclude_brands": "Excluded Brands",
+                    "include_brands": "Included Brands",
+                    "exclude_stations": "Excluded Stations",
+                    "include_stations": "Included Stations"
+                }
             }
         }
     },

--- a/custom_components/gasbuddy/translations/es.json
+++ b/custom_components/gasbuddy/translations/es.json
@@ -77,6 +77,24 @@
                     "fuel_key": "Tipo de combustible",
                     "price_type": "Tipo de precio"
                 }
+            },
+            "cheapest_filters": {
+                "description": "Configure los filtros de marcas y estaciones para restringir las estaciones rastreadas.",
+                "data": {
+                    "exclude_brands": "Marcas excluidas",
+                    "include_brands": "Marcas incluidas",
+                    "exclude_stations": "Estaciones excluidas",
+                    "include_stations": "Estaciones incluidas"
+                }
+            },
+            "reconfigure_cheapest_filters": {
+                "description": "Configure los filtros de marcas y estaciones para restringir las estaciones rastreadas.",
+                "data": {
+                    "exclude_brands": "Marcas excluidas",
+                    "include_brands": "Marcas incluidas",
+                    "exclude_stations": "Estaciones excluidas",
+                    "include_stations": "Estaciones incluidas"
+                }
             }
         }
     },

--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -77,6 +77,24 @@
                     "fuel_key": "Type de carburant",
                     "price_type": "Type de prix"
                 }
+            },
+            "cheapest_filters": {
+                "description": "Configurez les filtres de marques et de stations pour limiter les stations suivies.",
+                "data": {
+                    "exclude_brands": "Marques exclues",
+                    "include_brands": "Marques incluses",
+                    "exclude_stations": "Stations exclues",
+                    "include_stations": "Stations incluses"
+                }
+            },
+            "reconfigure_cheapest_filters": {
+                "description": "Configurez les filtres de marques et de stations pour limiter les stations suivies.",
+                "data": {
+                    "exclude_brands": "Marques exclues",
+                    "include_brands": "Marques incluses",
+                    "exclude_stations": "Stations exclues",
+                    "include_stations": "Stations incluses"
+                }
             }
         }
     },

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -77,6 +77,24 @@
                     "fuel_key": "Tipo de combustível",
                     "price_type": "Tipo de preço"
                 }
+            },
+            "cheapest_filters": {
+                "description": "Configure os filtros de marcas e estações para limitar as estações rastreadas.",
+                "data": {
+                    "exclude_brands": "Marcas excluídas",
+                    "include_brands": "Marcas incluídas",
+                    "exclude_stations": "Estações excluídas",
+                    "include_stations": "Estações incluídas"
+                }
+            },
+            "reconfigure_cheapest_filters": {
+                "description": "Configure os filtros de marcas e estações para limitar as estações rastreadas.",
+                "data": {
+                    "exclude_brands": "Marcas excluídas",
+                    "include_brands": "Marcas incluídas",
+                    "exclude_stations": "Estações excluídas",
+                    "include_stations": "Estações incluídas"
+                }
             }
         }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from aioresponses import CallbackResult
-from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, MissingSearchData
+from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, LibraryError, MissingSearchData
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -14,6 +14,7 @@ from custom_components.gasbuddy.config_flow import (
     InvalidStation,
     SearchFailed,
     _csrf_blocked_via_state,  # noqa: PLC2701
+    _get_nearby_brands_and_stations,  # noqa: PLC2701
     _get_station_list,  # noqa: PLC2701
     _lon_delta,  # noqa: PLC2701
     validate_station,
@@ -21,9 +22,13 @@ from custom_components.gasbuddy.config_flow import (
 from custom_components.gasbuddy.const import (
     CONF_CHEAPEST,
     CONF_EV_CHARGING,
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
     CONF_FUEL_KEY,
     CONF_GPS,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
     CONF_INTERVAL,
     CONF_NAME,
     CONF_POSTAL,
@@ -40,7 +45,7 @@ from homeassistant import config_entries, setup
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from tests.common import load_fixture
-from tests.const import CONFIG_DATA, STATION_LIST
+from tests.const import CONFIG_DATA, CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST, STATION_LIST
 
 BASE_URL = "https://www.gasbuddy.com/graphql"
 GB_URL = "https://www.gasbuddy.com/home"
@@ -1914,10 +1919,16 @@ async def test_cheapest_flow_gps(hass):
     )
     assert result["type"] == FlowResultType.MENU
 
-    with patch(
-        "custom_components.gasbuddy.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    with (
+        patch(
+            "custom_components.gasbuddy.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+        patch(
+            "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+            return_value=({"brand_1": "Shell"}, {"111": "Shell (100 Main St)"}),
+        ),
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"next_step_id": "cheapest"}
         )
@@ -1934,6 +1945,19 @@ async def test_cheapest_flow_gps(hass):
                 CONF_SOLVER: "",
             },
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "cheapest_filters"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EXCLUDE_BRANDS: ["brand_1"],
+                CONF_INCLUDE_BRANDS: [],
+                CONF_EXCLUDE_STATIONS: [],
+                CONF_INCLUDE_STATIONS: ["111"],
+            },
+        )
+
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == "Cheapest Gas"
         assert result["data"][CONF_CHEAPEST] is True
@@ -1941,6 +1965,8 @@ async def test_cheapest_flow_gps(hass):
         assert result["data"][CONF_PRICE_TYPE] == "best"
         assert CONF_POSTAL not in result["data"]
         assert result["data"][CONF_SOLVER] is None
+        assert result["data"][CONF_EXCLUDE_BRANDS] == ["brand_1"]
+        assert result["data"][CONF_INCLUDE_STATIONS] == ["111"]
         assert result["options"][CONF_EV_CHARGING] is False
         assert result["options"][CONF_FETCH_GAS] is True
 
@@ -1955,9 +1981,15 @@ async def test_cheapest_flow_postal(hass):
     )
     assert result["type"] == FlowResultType.MENU
 
-    with patch(
-        "custom_components.gasbuddy.async_setup_entry",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.gasbuddy.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+            return_value=({}, {}),
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"next_step_id": "cheapest"}
@@ -1970,6 +2002,18 @@ async def test_cheapest_flow_postal(hass):
                 CONF_FUEL_KEY: "premium_gas",
                 CONF_PRICE_TYPE: "cash",
                 CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "cheapest_filters"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EXCLUDE_BRANDS: [],
+                CONF_INCLUDE_BRANDS: [],
+                CONF_EXCLUDE_STATIONS: [],
+                CONF_INCLUDE_STATIONS: [],
             },
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -2070,7 +2114,6 @@ async def test_reconfigure_invalid_station_id_format(hass, integration):
 @pytest.mark.asyncio
 async def test_reconfigure_cheapest_show_form(hass):
     """Reconfigure for a cheapest entry shows the cheapest form (lines 775, 856)."""
-    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2092,7 +2135,6 @@ async def test_reconfigure_cheapest_show_form(hass):
 @pytest.mark.asyncio
 async def test_reconfigure_cheapest_success(hass):
     """Reconfigure cheapest entry with valid data succeeds (lines 823-850)."""
-    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2108,7 +2150,13 @@ async def test_reconfigure_cheapest_success(hass):
         context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
     )
 
-    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+    with (
+        patch("homeassistant.config_entries.ConfigEntries.async_reload"),
+        patch(
+            "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+            return_value=({}, {}),
+        ),
+    ):
         result = await hass.config_entries.flow.async_configure(
             reconfigure_result["flow_id"],
             {
@@ -2117,6 +2165,18 @@ async def test_reconfigure_cheapest_success(hass):
                 CONF_FUEL_KEY: "premium_gas",
                 CONF_PRICE_TYPE: "cash",
                 CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure_cheapest_filters"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EXCLUDE_BRANDS: [],
+                CONF_INCLUDE_BRANDS: [],
+                CONF_EXCLUDE_STATIONS: [],
+                CONF_INCLUDE_STATIONS: [],
             },
         )
 
@@ -2129,7 +2189,6 @@ async def test_reconfigure_cheapest_success(hass):
 @pytest.mark.asyncio
 async def test_reconfigure_cheapest_invalid_solver(hass):
     """Reconfigure cheapest entry rejects invalid solver URL (lines 828-829)."""
-    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2191,7 +2250,6 @@ async def test_station_list_cache_eviction(hass):
 @pytest.mark.asyncio
 async def test_reconfigure_cheapest_clears_postal(hass):
     """Reconfigure cheapest entry removes postal when submitted blank (line 843)."""
-    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
 
     config_with_postal = {**CONFIG_DATA_CHEAPEST, CONF_POSTAL: "12345"}
     entry = MockConfigEntry(
@@ -2208,7 +2266,13 @@ async def test_reconfigure_cheapest_clears_postal(hass):
         context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
     )
 
-    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+    with (
+        patch("homeassistant.config_entries.ConfigEntries.async_reload"),
+        patch(
+            "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+            return_value=({}, {}),
+        ),
+    ):
         result = await hass.config_entries.flow.async_configure(
             reconfigure_result["flow_id"],
             {
@@ -2217,6 +2281,18 @@ async def test_reconfigure_cheapest_clears_postal(hass):
                 CONF_FUEL_KEY: "regular_gas",
                 CONF_PRICE_TYPE: "best",
                 CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure_cheapest_filters"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EXCLUDE_BRANDS: [],
+                CONF_INCLUDE_BRANDS: [],
+                CONF_EXCLUDE_STATIONS: [],
+                CONF_INCLUDE_STATIONS: [],
             },
         )
 
@@ -2254,7 +2330,6 @@ async def test_cheapest_flow_invalid_postal(hass):
 @pytest.mark.asyncio
 async def test_reconfigure_cheapest_invalid_postal(hass):
     """Reconfigure cheapest entry rejects invalid postal code."""
-    from tests.const import CONFIG_DATA_CHEAPEST, OPTIONS_CHEAPEST  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2485,3 +2560,172 @@ async def test_station_list_cloudflare_blocked(hass):
 async def test_lon_delta(a, b, expected):
     """Longitude delta takes the short way around the antimeridian."""
     assert _lon_delta(a, b) == pytest.approx(expected)
+
+
+async def test_get_nearby_brands_and_stations_success(hass):
+    """Test _get_nearby_brands_and_stations returns brands and stations correctly."""
+    fake_results = {
+        "results": [
+            {
+                "station_id": "111",
+                "name": "Station A",
+                "address": {"line1": "123 Main St"},
+                "brands": [{"brandId": "brand_1", "name": "Brand A"}],
+            },
+            {
+                "id": "222",
+                "name": "Station B",
+                "address": {},
+                "brands": [{"brandId": "brand_2", "name": "Brand B"}],
+            },
+            {
+                "station_id": None,
+                "name": "Station C",
+            },
+        ]
+    }
+
+    with patch(
+        "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+        return_value=fake_results,
+    ):
+        brands, stations = await _get_nearby_brands_and_stations(
+            hass, "12345", "http://solver", 5000
+        )
+
+    assert brands == {"brand_1": "Brand A", "brand_2": "Brand B"}
+    assert stations == {"111": "Station A (123 Main St)", "222": "Station B"}
+
+
+async def test_get_nearby_brands_and_stations_exception(hass):
+    """Test _get_nearby_brands_and_stations returns empty dicts on exception."""
+    with patch(
+        "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+        side_effect=Exception("API failure"),
+    ):
+        brands, stations = await _get_nearby_brands_and_stations(hass, None, None, 5000)
+
+    assert brands == {}
+    assert stations == {}
+
+
+async def test_get_nearby_brands_and_stations_cloudflare(hass):
+    """Test _get_nearby_brands_and_stations raises CloudflareBlocked on CSRFTokenMissing/sentinel check."""
+    # Test CSRFTokenMissing raises CloudflareBlocked
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+            side_effect=CSRFTokenMissing,
+        ),
+        pytest.raises(CloudflareBlocked),
+    ):
+        await _get_nearby_brands_and_stations(hass, None, None, 5000)
+
+    # Test APIError with sentinel returns True raises CloudflareBlocked
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+            side_effect=APIError("Cloudflare block"),
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            return_value=True,
+        ),
+        pytest.raises(CloudflareBlocked),
+    ):
+        await _get_nearby_brands_and_stations(hass, None, None, 5000)
+
+    # Test LibraryError with sentinel returns True raises CloudflareBlocked
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+            side_effect=LibraryError("Library block"),
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            return_value=True,
+        ),
+        pytest.raises(CloudflareBlocked),
+    ):
+        await _get_nearby_brands_and_stations(hass, None, None, 5000)
+
+    # Test LibraryError with sentinel returns False returns empty dicts (no exception raised)
+    with (
+        patch(
+            "custom_components.gasbuddy.config_flow.py_gasbuddy.GasBuddy.price_lookup_service",
+            side_effect=LibraryError("Generic library error"),
+        ),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            return_value=False,
+        ),
+    ):
+        brands, stations = await _get_nearby_brands_and_stations(hass, None, None, 5000)
+    assert brands == {}
+    assert stations == {}
+
+
+async def test_cheapest_flow_cloudflare_blocked(hass):
+    """Cheapest config flow step 2 catches CloudflareBlocked and redirects to step 1."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "cheapest"}
+    )
+    assert result["step_id"] == "cheapest"
+
+    with patch(
+        "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+        side_effect=CloudflareBlocked,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Cheapest Gas",
+                CONF_POSTAL: "55904",
+                CONF_FUEL_KEY: "regular_gas",
+                CONF_PRICE_TYPE: "best",
+                CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "cheapest"
+        assert result["errors"] == {CONF_SOLVER: "cloudflare"}
+
+
+async def test_reconfigure_cheapest_cloudflare_blocked(hass):
+    """Reconfigure cheapest entry step 2 catches CloudflareBlocked and redirects to step 1."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Cheapest Gas",
+        data=CONFIG_DATA_CHEAPEST,
+        options=OPTIONS_CHEAPEST,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    assert reconfigure_result["step_id"] == "reconfigure"
+
+    with patch(
+        "custom_components.gasbuddy.config_flow._get_nearby_brands_and_stations",
+        side_effect=CloudflareBlocked,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            {
+                CONF_NAME: "Updated Cheapest",
+                CONF_POSTAL: "90210",
+                CONF_FUEL_KEY: "premium_gas",
+                CONF_PRICE_TYPE: "cash",
+                CONF_SOLVER: "",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+        assert result["errors"] == {CONF_SOLVER: "cloudflare"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,8 +7,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.gasbuddy import async_remove_config_entry_device
 from custom_components.gasbuddy.const import (
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
     CONF_GPS,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
     CONF_SOLVER,
     CONF_UOM,
     CONFIG_VER,
@@ -118,6 +122,10 @@ async def test_migrate_entry(hass, mock_gasbuddy):
     assert entry.data[CONF_UOM] is True
     assert entry.data[CONF_GPS] is True
     assert entry.data[CONF_SOLVER] is None
+    assert entry.data[CONF_EXCLUDE_BRANDS] == []
+    assert entry.data[CONF_INCLUDE_BRANDS] == []
+    assert entry.data[CONF_EXCLUDE_STATIONS] == []
+    assert entry.data[CONF_INCLUDE_STATIONS] == []
 
 
 async def test_migrate_entry_advances_version_without_data_change(hass, mock_gasbuddy):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,13 +1,21 @@
 """Test gasbuddy sensors."""
 
+import copy
 from unittest.mock import patch
 
+from py_gasbuddy.exceptions import APIError
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.gasbuddy.const import (
     CONF_EV_CHARGING,
+    CONF_EXCLUDE_BRANDS,
+    CONF_EXCLUDE_STATIONS,
     CONF_FETCH_GAS,
+    CONF_INCLUDE_BRANDS,
+    CONF_INCLUDE_STATIONS,
+    CONF_POSTAL,
+    CONF_PRICE_TYPE,
     CONF_STATION_ID,
     CONF_TIMEOUT,
     CONF_UOM,
@@ -25,6 +33,7 @@ from custom_components.gasbuddy.sensor import GasBuddySensor
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util.dt import as_utc, parse_datetime
 from tests.common import load_fixture
 
@@ -516,7 +525,6 @@ async def test_deal_sensor_enabled_without_pay_status(
 
 async def test_extra_attrs_deal_price_present_without_pay_status(hass, mock_gasbuddy, integration):
     """deal_price attribute appears when deal_price is set, even without pay_status (cheapest mode)."""
-    import copy  # noqa: PLC0415
 
     coordinator = hass.data[DOMAIN][integration.entry_id][COORDINATOR]
     original_data = coordinator.data
@@ -571,7 +579,6 @@ async def test_coordinator_cheapest_gps(hass):
 
 async def test_coordinator_cheapest_postal(hass):
     """Cheapest mode uses postal code when configured."""
-    from custom_components.gasbuddy.const import CONF_POSTAL  # noqa: PLC0415
 
     config = {**CONFIG_DATA_CHEAPEST, CONF_POSTAL: "12345"}
     entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
@@ -591,7 +598,6 @@ async def test_coordinator_cheapest_postal(hass):
 
 async def test_coordinator_cheapest_no_stations(hass):
     """Cheapest mode raises UpdateFailed when no station carries the fuel."""
-    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
@@ -606,9 +612,6 @@ async def test_coordinator_cheapest_no_stations(hass):
 
 async def test_coordinator_cheapest_api_error(hass):
     """Cheapest mode wraps API errors as UpdateFailed."""
-    from py_gasbuddy.exceptions import APIError  # noqa: PLC0415
-
-    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2
@@ -623,7 +626,6 @@ async def test_coordinator_cheapest_api_error(hass):
 
 async def test_coordinator_cheapest_sort_deal(hass):
     """Cheapest mode sort by deal price."""
-    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
 
     config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "deal"}
     entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
@@ -639,7 +641,6 @@ async def test_coordinator_cheapest_sort_deal(hass):
 
 async def test_coordinator_cheapest_sort_cash(hass):
     """Cheapest mode sort by cash price."""
-    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
 
     config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "cash"}
     entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
@@ -655,7 +656,6 @@ async def test_coordinator_cheapest_sort_cash(hass):
 
 async def test_coordinator_cheapest_sort_credit(hass):
     """Cheapest mode sort by credit price (fallback else branch)."""
-    from custom_components.gasbuddy.const import CONF_PRICE_TYPE  # noqa: PLC0415
 
     config = {**CONFIG_DATA_CHEAPEST, CONF_PRICE_TYPE: "credit"}
     entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=2)
@@ -667,6 +667,115 @@ async def test_coordinator_cheapest_sort_credit(hass):
     ):
         data = await coordinator._async_update_data()  # noqa: SLF001
     assert data["station_id"] == "222"
+
+
+async def test_coordinator_cheapest_filtering(hass):
+    """Test coordinator filtering in cheapest mode."""
+
+    stations = [
+        {
+            "station_id": "111",
+            "name": "Expensive Station",
+            "regular_gas": {"price": 4.00, "cash_price": 3.90, "deal_price": 3.80},
+            "brands": [{"brandId": "brand_exp", "name": "Brand Exp"}],
+        },
+        {
+            "station_id": "222",
+            "name": "Cheap Station",
+            "regular_gas": {"price": 3.20, "cash_price": 3.10, "deal_price": 3.00},
+            "brands": [{"brandId": "brand_cheap", "name": "Brand Cheap"}],
+        },
+    ]
+
+    # Test 1: Exclude the cheapest brand (should select Expensive)
+    config = {
+        **CONFIG_DATA_CHEAPEST,
+        CONF_EXCLUDE_BRANDS: ["brand_cheap"],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=8)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "111"
+
+    # Test 2: Include only the expensive brand (should select Expensive)
+    config = {
+        **CONFIG_DATA_CHEAPEST,
+        CONF_INCLUDE_BRANDS: ["brand_exp"],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=8)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "111"
+
+    # Test 3: Exclude the cheapest station (should select Expensive)
+    config = {
+        **CONFIG_DATA_CHEAPEST,
+        CONF_EXCLUDE_STATIONS: ["222"],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=8)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "111"
+
+    # Test 4: Include only the expensive station (should select Expensive)
+    config = {
+        **CONFIG_DATA_CHEAPEST,
+        CONF_INCLUDE_STATIONS: ["111"],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=8)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["station_id"] == "111"
+
+
+async def test_coordinator_cheapest_filtering_no_stations(hass):
+    """Test coordinator filtering in cheapest mode raises UpdateFailed if no stations remain."""
+
+    stations = [
+        {
+            "station_id": "111",
+            "name": "Expensive Station",
+            "regular_gas": {"price": 4.00, "cash_price": 3.90, "deal_price": 3.80},
+            "brands": [{"brandId": "brand_exp", "name": "Brand Exp"}],
+        },
+    ]
+
+    # Exclude the only station's brand (should raise UpdateFailed)
+    config = {
+        **CONFIG_DATA_CHEAPEST,
+        CONF_EXCLUDE_BRANDS: ["brand_exp"],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, options=OPTIONS_CHEAPEST, version=8)
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with (
+        patch.object(
+            coordinator._api,  # noqa: SLF001
+            "price_lookup_service",
+            return_value={"results": stations},
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()  # noqa: SLF001
 
 
 async def test_fuels_list_enables_sensors(hass, entity_registry: er.EntityRegistry):
@@ -694,7 +803,6 @@ async def test_fuels_list_enables_sensors(hass, entity_registry: er.EntityRegist
 
 async def test_coordinator_cheapest_no_valid_prices(hass):
     """Cheapest mode raises UpdateFailed when all stations have no finite price."""
-    from homeassistant.helpers.update_coordinator import UpdateFailed  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=2

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,6 +1,7 @@
 """Test gasbuddy services."""
 
 import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -13,6 +14,7 @@ from custom_components.gasbuddy.const import (
     DOMAIN,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from tests.common import load_fixture
 
@@ -315,7 +317,6 @@ async def test_clear_cache(
 
 async def test_lookup_gps_invalid_solver(hass, mock_gasbuddy, mock_aioclient):
     """lookup_gps raises ServiceValidationError for invalid solver URL (services.py line 53)."""
-    from homeassistant.exceptions import ServiceValidationError  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -342,7 +343,6 @@ async def test_lookup_gps_invalid_solver(hass, mock_gasbuddy, mock_aioclient):
 
 async def test_clear_cache_no_config_entry(hass, mock_gasbuddy, mock_aioclient, caplog):
     """clear_cache raises ValueError when device has no config entry (services.py line 295)."""
-    from unittest.mock import MagicMock, patch  # noqa: PLC0415
 
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change
This PR implements brand and station inclusion/exclusion filters for the 'Cheapest Nearby' gas tracking mode. It dynamically retrieves nearby stations and shows brand and station filters in multi-select dropdowns in the config and reconfig flows.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #290
- This PR is related to issue:

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated in `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional include/exclude filters for brands and stations in the cheapest gas tracker, allowing users to restrict price tracking to preferred options.
  * Improved configuration flow with dedicated steps for setting up and reconfiguring brand and station filter preferences during integration setup and changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->