### PR TITLE
feat: add Station Address sensor for cheapest gas subentries

### DIFF
--- a/custom_components/gasbuddy/const.py
+++ b/custom_components/gasbuddy/const.py
@@ -260,6 +260,14 @@ SENSOR_TYPES: Final[dict[str, GasBuddySensorEntityDescription]] = {
         price=False,
         entity_registry_enabled_default=False,
     ),
+    "station_address": GasBuddySensorEntityDescription(
+        key="station_address",
+        name="Station Address",
+        icon="mdi:map-marker",
+        price=False,
+        cheapest_only=True,
+        entity_registry_enabled_default=False,
+    ),
     # EV Charging Sensors
     "ev_level1": GasBuddySensorEntityDescription(
         key="ev_level1",

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -98,6 +98,8 @@ def format_address(addr: dict | None) -> str | None:
             addr.get("line1") or addr.get("line2") or "",
             addr.get("locality") or "",
             addr.get("region") or "",
+            addr.get("postalCode") or addr.get("postal_code") or "",
+            addr.get("country") or "",
         )
         if part and part.strip()
     ]

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -417,6 +417,16 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
             )
         cheapest = min(finite, key=operator.itemgetter(1))[0]
         cheapest["last_updated"] = datetime.now(UTC)
+        if addr := cheapest.get("address"):
+            cheapest["station_address"] = ", ".join(
+                part
+                for part in (
+                    addr.get("line1", ""),
+                    addr.get("locality", ""),
+                    addr.get("region", ""),
+                )
+                if part
+            )
         _LOGGER.debug("Cheapest gas station: %s", _redact(cheapest))
         return cheapest
 

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -88,6 +88,22 @@ def _cache_path(hass: HomeAssistant) -> str:
     return f"{hass.config.config_dir}/{CACHE_FILE_NAME}"
 
 
+def format_address(addr: dict | None) -> str | None:
+    """Format an address dict into a string with only non-empty parts."""
+    if not addr:
+        return None
+    parts = [
+        part.strip()
+        for part in (
+            addr.get("line1") or addr.get("line2") or "",
+            addr.get("locality") or "",
+            addr.get("region") or "",
+        )
+        if part and part.strip()
+    ]
+    return ", ".join(parts) if parts else None
+
+
 class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
@@ -418,15 +434,8 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         cheapest = min(finite, key=operator.itemgetter(1))[0]
         cheapest["last_updated"] = datetime.now(UTC)
         if addr := cheapest.get("address"):
-            cheapest["station_address"] = ", ".join(
-                part
-                for part in (
-                    addr.get("line1", ""),
-                    addr.get("locality", ""),
-                    addr.get("region", ""),
-                )
-                if part
-            )
+            if formatted := format_address(addr):
+                cheapest["station_address"] = formatted
         _LOGGER.debug("Cheapest gas station: %s", _redact(cheapest))
         return cheapest
 

--- a/custom_components/gasbuddy/entity.py
+++ b/custom_components/gasbuddy/entity.py
@@ -14,3 +14,4 @@ class GasBuddySensorEntityDescription(SensorEntityDescription):
     cash: bool | None = None
     deal: bool | None = None
     price: bool | None = True
+    cheapest_only: bool = False

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.util.dt import as_utc, parse_datetime
 
 from .const import (
     ATTR_IMAGEURL,
+    CONF_CHEAPEST,
     CONF_EV_CHARGING,
     CONF_FETCH_GAS,
     CONF_GPS,
@@ -68,9 +69,12 @@ async def async_setup_entry(
                 continue
             if (
                 not sensor_type.startswith("ev_")
-                and sensor_type not in {"last_updated", "open_status", "station_name"}
+                and sensor_type
+                not in {"last_updated", "open_status", "station_name", "station_address"}
                 and not fetch_gas
             ):
+                continue
+            if description.cheapest_only and not subentry.data.get(CONF_CHEAPEST):
                 continue
 
             enabled = description.entity_registry_enabled_default
@@ -222,9 +226,13 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
         attrs: dict[str, Any] = {}
 
         if not self._price:
-            if not self._type.startswith("ev_") and self._type not in {"open_status", "name"}:
+            if not self._type.startswith("ev_") and self._type not in {
+                "open_status",
+                "name",
+                "station_address",
+            }:
                 return None
-            if self._type in {"open_status", "name"}:
+            if self._type in {"open_status", "name", "station_address"}:
                 return None
             attrs[CONF_STATION_ID] = data.get(CONF_STATION_ID)
             attrs["station_name"] = data.get("ev_station_name")
@@ -304,6 +312,7 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
             or self._type not in data
             or data[self._type] is None
         ):
+            # station_address may be absent (station has no address data) — treat as unavailable
             return False
 
         if self._price:

--- a/custom_components/gasbuddy/sensor.py
+++ b/custom_components/gasbuddy/sensor.py
@@ -30,7 +30,7 @@ from .const import (
     SENSOR_TYPES,
     UNIT_OF_MEASURE,
 )
-from .coordinator import GasBuddyUpdateCoordinator
+from .coordinator import GasBuddyUpdateCoordinator, format_address
 from .entity import GasBuddySensorEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
@@ -217,40 +217,45 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
             return currency
         return None
 
+    def _ev_attributes(self, data: dict) -> dict[str, Any] | None:
+        """Return EV and non-price sensor attributes."""
+        if not self._type.startswith("ev_") and self._type not in {
+            "open_status",
+            "name",
+            "station_address",
+        }:
+            return None
+        if self._type in {"open_status", "name", "station_address"}:
+            return None
+        attrs: dict[str, Any] = {}
+        attrs[CONF_STATION_ID] = data.get(CONF_STATION_ID)
+        attrs["station_name"] = data.get("ev_station_name")
+        attrs["station_address"] = data.get("ev_station_address")
+        if data.get("ev_distance_miles") is not None:
+            attrs["distance_miles"] = data.get("ev_distance_miles")
+        if data.get("ev_network") is not None:
+            attrs["network"] = data.get("ev_network")
+        if self._type == "ev_network" and data.get("ev_network_web") is not None:
+            attrs["website"] = data.get("ev_network_web")
+        if data.get("ev_pricing") is not None:
+            attrs["pricing"] = data.get("ev_pricing")
+        if data.get("ev_access_hours") is not None:
+            attrs["access_hours"] = data.get("ev_access_hours")
+        if self._get_setting(CONF_GPS):
+            attrs[ATTR_LATITUDE] = data.get(ATTR_LATITUDE)
+            attrs[ATTR_LONGITUDE] = data.get(ATTR_LONGITUDE)
+        return attrs
+
     @property
     def extra_state_attributes(self) -> dict | None:
         """Return sesnsor attributes."""
         if not (data := self.coordinator.data):
             return None
 
-        attrs: dict[str, Any] = {}
-
         if not self._price:
-            if not self._type.startswith("ev_") and self._type not in {
-                "open_status",
-                "name",
-                "station_address",
-            }:
-                return None
-            if self._type in {"open_status", "name", "station_address"}:
-                return None
-            attrs[CONF_STATION_ID] = data.get(CONF_STATION_ID)
-            attrs["station_name"] = data.get("ev_station_name")
-            attrs["station_address"] = data.get("ev_station_address")
-            if data.get("ev_distance_miles") is not None:
-                attrs["distance_miles"] = data.get("ev_distance_miles")
-            if data.get("ev_network") is not None:
-                attrs["network"] = data.get("ev_network")
-            if self._type == "ev_network" and data.get("ev_network_web") is not None:
-                attrs["website"] = data.get("ev_network_web")
-            if data.get("ev_pricing") is not None:
-                attrs["pricing"] = data.get("ev_pricing")
-            if data.get("ev_access_hours") is not None:
-                attrs["access_hours"] = data.get("ev_access_hours")
-            if self._get_setting(CONF_GPS):
-                attrs[ATTR_LATITUDE] = data.get(ATTR_LATITUDE)
-                attrs[ATTR_LONGITUDE] = data.get(ATTR_LONGITUDE)
-            return attrs
+            return self._ev_attributes(data)
+
+        attrs: dict[str, Any] = {}
 
         if self._type not in data:
             return None
@@ -270,9 +275,8 @@ class GasBuddySensor(CoordinatorEntity, SensorEntity):  # pylint: disable=too-ma
         if rating := data.get("star_rating"):
             attrs["star_rating"] = rating
         if addr := data.get("address"):
-            attrs["address"] = (
-                f"{addr.get('line1', '')}, {addr.get('locality', '')}, {addr.get('region', '')}"
-            )
+            if formatted := format_address(addr):
+                attrs["address"] = formatted
         if amenities := data.get("amenities"):
             attrs["amenities"] = ", ".join(a["name"] for a in amenities if a.get("name"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,14 @@ from custom_components.gasbuddy.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigSubentry
-from tests.const import COORDINATOR_DATA, COORDINATOR_DATA_CAD, HUB_DATA, STATION_SUBENTRY_DATA
+from tests.const import (
+    CHEAPEST_SUBENTRY_DATA,
+    COORDINATOR_DATA,
+    COORDINATOR_DATA_CAD,
+    COORDINATOR_DATA_CHEAPEST,
+    HUB_DATA,
+    STATION_SUBENTRY_DATA,
+)
 
 original_init = common.MockConfigEntry.__init__
 
@@ -169,6 +176,27 @@ def _make_station_subentry(
     )
 
 
+def _make_cheapest_subentry(
+    *,
+    title: str = "Cheapest Gas",
+    unique_id: str = "cheapest_subentry_id",
+    subentry_id: str = "cheapest_subentry_id",
+    data: dict | MappingProxyType | None = None,
+) -> ConfigSubentry:
+    """Return a cheapest-gas ConfigSubentry (pass it to _make_hub_entry's subentries list)."""
+    if data is None:
+        data = CHEAPEST_SUBENTRY_DATA
+    if not isinstance(data, MappingProxyType):
+        data = MappingProxyType(data)
+    return ConfigSubentry(
+        data=data,
+        subentry_type="station",
+        title=title,
+        unique_id=unique_id,
+        subentry_id=subentry_id,
+    )
+
+
 def _make_hub_entry(
     hass,
     hub_data: dict | None = None,
@@ -220,6 +248,16 @@ def mock_gasbuddy_cad():
         "custom_components.gasbuddy.GasBuddyUpdateCoordinator._async_update_data"
     ) as mock_value:
         mock_value.return_value = COORDINATOR_DATA_CAD
+        yield
+
+
+@pytest.fixture
+def mock_gasbuddy_cheapest():
+    """Mock cheapest-gas coordinator data."""
+    with patch(
+        "custom_components.gasbuddy.GasBuddyUpdateCoordinator._async_update_data"
+    ) as mock_value:
+        mock_value.return_value = COORDINATOR_DATA_CHEAPEST
         yield
 
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -198,7 +198,7 @@ COORDINATOR_DATA_CHEAPEST = {
         "postalCode": "55904",
         "country": "US",
     },
-    "station_address": "400 4th St SE, Rochester, MN",
+    "station_address": "400 4th St SE, Rochester, MN, 55904, US",
     "regular_gas": {
         "credit": "user99",
         "price": 2.89,

--- a/tests/const.py
+++ b/tests/const.py
@@ -191,6 +191,14 @@ COORDINATOR_DATA_CHEAPEST = {
     "latitude": 41.8800,
     "longitude": -87.6300,
     "distance": 0.5,
+    "address": {
+        "line1": "400 4th St SE",
+        "locality": "Rochester",
+        "region": "MN",
+        "postalCode": "55904",
+        "country": "US",
+    },
+    "station_address": "400 4th St SE, Rochester, MN",
     "regular_gas": {
         "credit": "user99",
         "price": 2.89,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -500,7 +500,7 @@ async def test_extra_attrs_richer(hass, mock_gasbuddy, integration):
     assert attrs.get("deal_price") == 2.78
     assert attrs.get("phone") == "555-555-5555"
     assert attrs.get("star_rating") == 4.2
-    assert attrs.get("address") == "100 Test Blvd, Springfield, IL"
+    assert attrs.get("address") == "100 Test Blvd, Springfield, IL, 62701, US"
     assert attrs.get("amenities") == "ATM, Restrooms"
 
 
@@ -1024,7 +1024,7 @@ async def test_coordinator_cheapest_station_address(hass):
     ):
         data = await coordinator._async_update_data()  # noqa: SLF001
 
-    assert data["station_address"] == "123 Main St, Springfield, IL"
+    assert data["station_address"] == "123 Main St, Springfield, IL, 62701, US"
 
 
 async def test_coordinator_cheapest_station_address_empty(hass):
@@ -1110,7 +1110,7 @@ async def test_cheapest_station_address_sensor_state(hass, mock_gasbuddy_cheapes
 
     state = hass.states.get(address_entries[0].entity_id)
     assert state is not None
-    assert state.state == "400 4th St SE, Rochester, MN"
+    assert state.state == "400 4th St SE, Rochester, MN, 55904, US"
 
     # station_address must NOT be registered for any non-cheapest subentry
     regular_address = [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,6 +35,7 @@ from custom_components.gasbuddy.const import (
 from custom_components.gasbuddy.coordinator import (
     GasBuddyUpdateCoordinator,
     _redact,  # noqa: PLC2701
+    format_address,
 )
 from custom_components.gasbuddy.sensor import GasBuddySensor
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -43,7 +44,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util.dt import as_utc, parse_datetime
 from tests.common import load_fixture
-from tests.conftest import _make_hub_entry, _make_station_subentry
+from tests.conftest import _make_cheapest_subentry, _make_hub_entry, _make_station_subentry
 
 from .const import (
     CONFIG_DATA,
@@ -1073,8 +1074,6 @@ async def test_coordinator_cheapest_station_address_empty(hass):
 
 def test_format_address_helper():
     """Verify that format_address helper handles None and empty values correctly."""
-    from custom_components.gasbuddy.coordinator import format_address  # noqa: PLC0415
-
     assert format_address(None) is None
     assert format_address({}) is None
     assert format_address({"line1": "  ", "locality": ""}) is None
@@ -1085,8 +1084,6 @@ async def test_cheapest_station_address_sensor_state(hass, mock_gasbuddy_cheapes
 
     Also verifies the sensor is absent on regular (non-cheapest) station subentries.
     """
-    from tests.conftest import _make_cheapest_subentry, _make_hub_entry  # noqa: PLC0415
-
     cheapest_sub = _make_cheapest_subentry()
     entry = _make_hub_entry(hass, subentries=[cheapest_sub])
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -1322,7 +1319,6 @@ async def test_sensor_device_registered_under_hub_entry(hass, mock_gasbuddy):
     is created — HA groups them via the integration card natively.
     """
     from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
-    from tests.conftest import _make_hub_entry  # noqa: PLC0415
 
     entry = _make_hub_entry(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -992,6 +992,86 @@ async def test_coordinator_cheapest_brand_adjustments_edge_cases(hass):
     assert data["station_id"] == "222"
 
 
+async def test_coordinator_cheapest_station_address(hass):
+    """Cheapest coordinator flattens the address dict into station_address.
+
+    Covers coordinator.py: the if-addr block in _async_update_cheapest that produces
+    a formatted station_address string from the raw address dict.
+    """
+    stations = [
+        {
+            "station_id": "400",
+            "name": "Address Station",
+            "address": {
+                "line1": "123 Main St",
+                "locality": "Springfield",
+                "region": "IL",
+                "postalCode": "62701",
+                "country": "US",
+            },
+            "regular_gas": {"price": 3.10, "cash_price": None, "deal_price": None},
+        }
+    ]
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=9
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data["station_address"] == "123 Main St, Springfield, IL"
+
+
+async def test_cheapest_station_address_sensor_state(hass, mock_gasbuddy_cheapest):
+    """station_address sensor appears on cheapest subentries with correct state.
+
+    Also verifies the sensor is absent on regular (non-cheapest) station subentries.
+    """
+    from tests.conftest import _make_cheapest_subentry, _make_hub_entry  # noqa: PLC0415
+
+    cheapest_sub = _make_cheapest_subentry()
+    entry = _make_hub_entry(hass, subentries=[cheapest_sub])
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # station_address is disabled by default — verify it exists in the entity registry
+    entity_registry = er.async_get(hass)
+    address_entries = [
+        e
+        for e in entity_registry.entities.values()
+        if e.config_subentry_id == "cheapest_subentry_id"
+        and e.domain == "sensor"
+        and "station_address" in e.entity_id
+    ]
+    assert len(address_entries) == 1, (
+        "station_address sensor must be registered for cheapest subentry"
+    )
+    assert address_entries[0].disabled_by is not None, "sensor must be disabled by default"
+
+    # Enable the sensor and verify its state
+    entity_registry.async_update_entity(address_entries[0].entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(address_entries[0].entity_id)
+    assert state is not None
+    assert state.state == "400 4th St SE, Rochester, MN"
+
+    # station_address must NOT be registered for any non-cheapest subentry
+    regular_address = [
+        e
+        for e in entity_registry.entities.values()
+        if e.domain == "sensor"
+        and "station_address" in e.entity_id
+        and e.config_subentry_id != "cheapest_subentry_id"
+    ]
+    assert regular_address == [], "station_address sensor should not appear on regular stations"
+
+
 async def test_sensor_brand_adjustments_options(hass, mock_aioclient):
     """Test sensor behavior with brand adjustments, discounted_price attribute and state toggle."""
     graphql_response_usd = {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1026,6 +1026,60 @@ async def test_coordinator_cheapest_station_address(hass):
     assert data["station_address"] == "123 Main St, Springfield, IL"
 
 
+async def test_coordinator_cheapest_station_address_empty(hass):
+    """Cheapest coordinator leaves station_address key unset if address fields are empty/None."""
+    # Test 1: Empty strings inside address dict
+    stations_empty_fields = [
+        {
+            "station_id": "400",
+            "name": "Empty Address Station",
+            "address": {
+                "line1": "",
+                "locality": "",
+                "region": "",
+            },
+            "regular_gas": {"price": 3.10, "cash_price": None, "deal_price": None},
+        }
+    ]
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=CONFIG_DATA_CHEAPEST, options=OPTIONS_CHEAPEST, version=9
+    )
+    coordinator = GasBuddyUpdateCoordinator(hass, entry)
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations_empty_fields},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert "station_address" not in data
+
+    # Test 2: Address is None/missing entirely
+    stations_no_address = [
+        {
+            "station_id": "400",
+            "name": "Empty Address Station",
+            "address": None,
+            "regular_gas": {"price": 3.10, "cash_price": None, "deal_price": None},
+        }
+    ]
+    with patch.object(
+        coordinator._api,  # noqa: SLF001
+        "price_lookup_service",
+        return_value={"results": stations_no_address},
+    ):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+    assert "station_address" not in data
+
+
+def test_format_address_helper():
+    """Verify that format_address helper handles None and empty values correctly."""
+    from custom_components.gasbuddy.coordinator import format_address  # noqa: PLC0415
+
+    assert format_address(None) is None
+    assert format_address({}) is None
+    assert format_address({"line1": "  ", "locality": ""}) is None
+
+
 async def test_cheapest_station_address_sensor_state(hass, mock_gasbuddy_cheapest):
     """station_address sensor appears on cheapest subentries with correct state.
 


### PR DESCRIPTION
## Proposed change

Adds a **Station Address** sensor to cheapest-gas subentries. When the coordinator picks the cheapest nearby station, the new sensor exposes its street address (`line1, locality, region`) as a dedicated entity — useful in automations and dashboards to display or announce which station is currently cheapest without digging into sensor attributes.

The sensor is **disabled by default** (matching the existing `station_name` sensor), and only appears on cheapest-gas subentries (`cheapest_only=True`). It does not appear on regular or EV station subentries, where the address is already available as an attribute on every price sensor.

### Changes

- **`entity.py`**: Added `cheapest_only: bool = False` field to `GasBuddySensorEntityDescription` to mark sensors that should only appear on cheapest-gas subentries.
- **`const.py`**: Added `"station_address"` to `SENSOR_TYPES` with `cheapest_only=True`, `entity_registry_enabled_default=False`.
- **`coordinator.py`**: In `_async_update_cheapest`, flattens the `address` dict (`line1`, `locality`, `region`) from the `price_lookup_service` result into a `station_address` string on the returned data dict.
- **`sensor.py`**: Added `cheapest_only` guard in `async_setup_entry`; added `station_address` to the non-price sensor exemption sets in `available` and `extra_state_attributes`.
- **`tests/const.py`**: Added `address` dict and pre-flattened `station_address` field to `COORDINATOR_DATA_CHEAPEST`.
- **`tests/conftest.py`**: Added `_make_cheapest_subentry` helper, `mock_gasbuddy_cheapest` fixture, and required imports.
- **`tests/test_sensor.py`**: Added `test_coordinator_cheapest_station_address` (address flattening in coordinator) and `test_cheapest_station_address_sensor_state` (entity registry presence, disabled-by-default, state value, and absence on regular subentries).

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #316 
- This PR is related to issue:

##

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in `README.md`

If the code communicates with devices, web services, or third-party tools:

- [x] The `manifest.json` file has all fields filled out correctly.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new station address sensor for cheapest-gas entries.
  * Address details are now shown as a single formatted location string when available.

* **Bug Fixes**
  * Improved handling of missing or incomplete address data so the sensor is only shown when usable information exists.
  * Kept address-related sensors hidden unless the relevant cheapest-gas option is enabled.

* **Tests**
  * Expanded coverage for address formatting, sensor availability, and cheapest-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->