### PR TITLE
feat: restore subentry configuration options and refactor latitude/longitude core constants

### DIFF
--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -7,6 +7,7 @@ import logging
 from types import MappingProxyType
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     config_validation as cv,
@@ -66,8 +67,8 @@ def _build_subentry_data_from_entry(entry: ConfigEntry) -> dict:
         CONF_STATION_ID,
         CONF_NAME,
         CONF_CHEAPEST,
-        "latitude",
-        "longitude",
+        CONF_LATITUDE,
+        CONF_LONGITUDE,
         CONF_EXCLUDE_BRANDS,
         CONF_INCLUDE_BRANDS,
         CONF_EXCLUDE_STATIONS,

--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_INCLUDE_STATIONS,
     CONF_INTERVAL,
     CONF_NAME,
+    CONF_SHOW_DISCOUNTED,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -84,6 +85,7 @@ def _build_subentry_data_from_entry(entry: ConfigEntry) -> dict:
         CONF_GPS,
         CONF_EV_CHARGING,
         CONF_FETCH_GAS,
+        CONF_SHOW_DISCOUNTED,
     ):
         if key in entry.options:
             data[key] = entry.options[key]

--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -89,8 +89,6 @@ def _build_subentry_data_from_entry(entry: ConfigEntry) -> dict:
     ):
         if key in entry.options:
             data[key] = entry.options[key]
-        elif key in entry.data:
-            data[key] = entry.data[key]
 
     # Preserve original entry_id for unique_id continuity
     data["old_entry_id"] = entry.entry_id

--- a/custom_components/gasbuddy/__init__.py
+++ b/custom_components/gasbuddy/__init__.py
@@ -89,6 +89,8 @@ def _build_subentry_data_from_entry(entry: ConfigEntry) -> dict:
     ):
         if key in entry.options:
             data[key] = entry.options[key]
+        elif key in entry.data:
+            data[key] = entry.data[key]
 
     # Preserve original entry_id for unique_id continuity
     data["old_entry_id"] = entry.entry_id

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import (
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -160,8 +161,8 @@ async def validate_station(
 
             return {
                 "type": "gas",
-                "latitude": gas_lat,
-                "longitude": gas_lon,
+                CONF_LATITUDE: gas_lat,
+                CONF_LONGITUDE: gas_lon,
             }
     except CSRFTokenMissing as ex:
         # Forward-compat: a future py_gasbuddy release may propagate
@@ -203,8 +204,8 @@ async def validate_station(
         if matching:
             return {
                 "type": "ev",
-                "latitude": matching.get("latitude"),
-                "longitude": matching.get("longitude"),
+                CONF_LATITUDE: matching.get("latitude"),
+                CONF_LONGITUDE: matching.get("longitude"),
             }
     except Exception as ev_ex:  # noqa: BLE001
         _LOGGER.warning("Error validating EV station: %s", ev_ex)
@@ -387,6 +388,16 @@ def _get_schema_manual(  # pylint: disable-next=unused-argument
         vol.Required(CONF_NAME, default=_get_default(CONF_NAME, DEFAULT_NAME)): vol.All(
             cv.string, vol.Strip, vol.Length(max=100)
         ),
+        vol.Required(CONF_INTERVAL, default=_get_default(CONF_INTERVAL, 3600)): vol.All(
+            cv.positive_int, vol.Range(min=900, max=14400)
+        ),
+        vol.Optional(CONF_UOM, default=_get_default(CONF_UOM, True)): cv.boolean,
+        vol.Optional(CONF_GPS, default=_get_default(CONF_GPS, True)): cv.boolean,
+        vol.Optional(CONF_EV_CHARGING, default=_get_default(CONF_EV_CHARGING, False)): cv.boolean,
+        vol.Optional(CONF_FETCH_GAS, default=_get_default(CONF_FETCH_GAS, True)): cv.boolean,
+        vol.Optional(
+            CONF_SHOW_DISCOUNTED, default=_get_default(CONF_SHOW_DISCOUNTED, False)
+        ): cv.boolean,
     })
 
 
@@ -668,14 +679,18 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
                 self._errors.setdefault(CONF_STATION_ID, "station_id")
 
             if len(self._errors) == 0:
-                if isinstance(validate, dict):
-                    self._data["latitude"] = validate.get("latitude")
-                    self._data["longitude"] = validate.get("longitude")
-                    self._data[CONF_EV_CHARGING] = validate["type"] == "ev"
-                    self._data[CONF_FETCH_GAS] = validate["type"] != "ev"
-                else:
-                    self._data[CONF_EV_CHARGING] = False
-                    self._data[CONF_FETCH_GAS] = True
+                if str(subentry.data.get(CONF_STATION_ID)) != station_id:
+                    if isinstance(validate, dict):
+                        self._data[CONF_LATITUDE] = validate.get(CONF_LATITUDE)
+                        self._data[CONF_LONGITUDE] = validate.get(CONF_LONGITUDE)
+                        self._data[CONF_EV_CHARGING] = validate["type"] == "ev"
+                        self._data[CONF_FETCH_GAS] = validate["type"] != "ev"
+                    else:
+                        self._data[CONF_EV_CHARGING] = False
+                        self._data[CONF_FETCH_GAS] = True
+                elif isinstance(validate, dict):
+                    self._data[CONF_LATITUDE] = validate.get(CONF_LATITUDE)
+                    self._data[CONF_LONGITUDE] = validate.get(CONF_LONGITUDE)
 
                 return self.async_update_and_abort(
                     self._get_entry(),
@@ -726,8 +741,8 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
             else:
                 self._data.update(user_input)
                 if isinstance(validate, dict):
-                    self._data["latitude"] = validate.get("latitude")
-                    self._data["longitude"] = validate.get("longitude")
+                    self._data[CONF_LATITUDE] = validate.get(CONF_LATITUDE)
+                    self._data[CONF_LONGITUDE] = validate.get(CONF_LONGITUDE)
                     ev_charging = validate["type"] == "ev"
                 else:
                     ev_charging = False
@@ -735,13 +750,14 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
                 subentry_data = {
                     CONF_STATION_ID: self._data[CONF_STATION_ID],
                     CONF_NAME: self._data.get(CONF_NAME, DEFAULT_NAME),
-                    "latitude": self._data.get("latitude"),
-                    "longitude": self._data.get("longitude"),
-                    CONF_INTERVAL: 3600,
-                    CONF_UOM: True,
-                    CONF_GPS: True,
-                    CONF_EV_CHARGING: ev_charging,
-                    CONF_FETCH_GAS: not ev_charging,
+                    CONF_LATITUDE: self._data.get(CONF_LATITUDE),
+                    CONF_LONGITUDE: self._data.get(CONF_LONGITUDE),
+                    CONF_INTERVAL: self._data.get(CONF_INTERVAL, 3600),
+                    CONF_UOM: self._data.get(CONF_UOM, True),
+                    CONF_GPS: self._data.get(CONF_GPS, True),
+                    CONF_EV_CHARGING: self._data.get(CONF_EV_CHARGING, ev_charging),
+                    CONF_FETCH_GAS: self._data.get(CONF_FETCH_GAS, not ev_charging),
+                    CONF_SHOW_DISCOUNTED: self._data.get(CONF_SHOW_DISCOUNTED, False),
                 }
                 return self.async_create_entry(
                     title=subentry_data[CONF_NAME],
@@ -752,7 +768,15 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
 
     async def _show_config_manual(self, user_input) -> SubentryFlowResult:
         """Show the configuration form to edit location data."""
-        defaults = {CONF_NAME: DEFAULT_NAME}
+        defaults = {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_INTERVAL: 3600,
+            CONF_UOM: True,
+            CONF_GPS: True,
+            CONF_EV_CHARGING: False,
+            CONF_FETCH_GAS: True,
+            CONF_SHOW_DISCOUNTED: False,
+        }
         return self.async_show_form(
             step_id="manual",
             data_schema=_get_schema_manual(self.hass, user_input, defaults),
@@ -1076,8 +1100,8 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
             return await self._show_config_manual(None)
 
         if isinstance(validate, dict):
-            self._data["latitude"] = validate.get("latitude")
-            self._data["longitude"] = validate.get("longitude")
+            self._data[CONF_LATITUDE] = validate.get(CONF_LATITUDE)
+            self._data[CONF_LONGITUDE] = validate.get(CONF_LONGITUDE)
             ev_charging = validate["type"] == "ev"
         else:
             ev_charging = False
@@ -1085,8 +1109,8 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
         subentry_data = {
             CONF_STATION_ID: self._data[CONF_STATION_ID],
             CONF_NAME: self._data.get(CONF_NAME, DEFAULT_NAME),
-            "latitude": self._data.get("latitude"),
-            "longitude": self._data.get("longitude"),
+            CONF_LATITUDE: self._data.get(CONF_LATITUDE),
+            CONF_LONGITUDE: self._data.get(CONF_LONGITUDE),
             CONF_INTERVAL: 3600,
             CONF_UOM: True,
             CONF_GPS: True,

--- a/custom_components/gasbuddy/config_flow.py
+++ b/custom_components/gasbuddy/config_flow.py
@@ -207,7 +207,9 @@ async def validate_station(
                 CONF_LATITUDE: matching.get("latitude"),
                 CONF_LONGITUDE: matching.get("longitude"),
             }
-    except Exception as ev_ex:  # noqa: BLE001
+    except Exception as ev_ex:
+        if _csrf_blocked_via_state(ev_gb):
+            raise CloudflareBlocked from ev_ex
         _LOGGER.warning("Error validating EV station: %s", ev_ex)
 
     if price_error is not None:
@@ -697,6 +699,7 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
                     self._get_reconfigure_subentry(),
                     data=self._data,
                     title=self._data.get(CONF_NAME, subentry.title),
+                    unique_id=str(self._data[CONF_STATION_ID]),
                 )
 
             return await self._show_reconfig_form(user_input)
@@ -743,9 +746,15 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
                 if isinstance(validate, dict):
                     self._data[CONF_LATITUDE] = validate.get(CONF_LATITUDE)
                     self._data[CONF_LONGITUDE] = validate.get(CONF_LONGITUDE)
-                    ev_charging = validate["type"] == "ev"
+                    if validate["type"] == "ev":
+                        self._data[CONF_EV_CHARGING] = True
+                        self._data[CONF_FETCH_GAS] = False
+                    else:
+                        self._data[CONF_EV_CHARGING] = self._data.get(CONF_EV_CHARGING, False)
+                        self._data[CONF_FETCH_GAS] = self._data.get(CONF_FETCH_GAS, True)
                 else:
-                    ev_charging = False
+                    self._data[CONF_EV_CHARGING] = self._data.get(CONF_EV_CHARGING, False)
+                    self._data[CONF_FETCH_GAS] = self._data.get(CONF_FETCH_GAS, True)
 
                 subentry_data = {
                     CONF_STATION_ID: self._data[CONF_STATION_ID],
@@ -755,8 +764,8 @@ class GasBuddySubentryFlowHandler(ConfigSubentryFlow):
                     CONF_INTERVAL: self._data.get(CONF_INTERVAL, 3600),
                     CONF_UOM: self._data.get(CONF_UOM, True),
                     CONF_GPS: self._data.get(CONF_GPS, True),
-                    CONF_EV_CHARGING: self._data.get(CONF_EV_CHARGING, ev_charging),
-                    CONF_FETCH_GAS: self._data.get(CONF_FETCH_GAS, not ev_charging),
+                    CONF_EV_CHARGING: self._data[CONF_EV_CHARGING],
+                    CONF_FETCH_GAS: self._data[CONF_FETCH_GAS],
                     CONF_SHOW_DISCOUNTED: self._data.get(CONF_SHOW_DISCOUNTED, False),
                 }
                 return self.async_create_entry(

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -180,8 +180,12 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(
                     "Both gas price polling and EV charging are disabled — nothing to fetch."
                 )
-            lat = self._subentry.data.get(CONF_LATITUDE) or self.hass.config.latitude
-            lon = self._subentry.data.get(CONF_LONGITUDE) or self.hass.config.longitude
+            lat = self._subentry.data.get(CONF_LATITUDE)
+            if lat is None:
+                lat = self.hass.config.latitude
+            lon = self._subentry.data.get(CONF_LONGITUDE)
+            if lon is None:
+                lon = self.hass.config.longitude
             self._data = {
                 "station_id": self._subentry.data[CONF_STATION_ID],
                 "name": self._subentry.data.get(CONF_NAME, "EV Station"),

--- a/custom_components/gasbuddy/coordinator.py
+++ b/custom_components/gasbuddy/coordinator.py
@@ -13,6 +13,7 @@ from py_gasbuddy import GasBuddy
 from py_gasbuddy.exceptions import APIError, CSRFTokenMissing, LibraryError
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -51,8 +52,8 @@ def _lon_delta(a: float, b: float) -> float:
 def _redact(data: Any) -> str:
     """Redact sensitive data for logging."""
     sensitive_keys = {
-        "latitude",
-        "longitude",
+        CONF_LATITUDE,
+        CONF_LONGITUDE,
         "street_address",
         "ev_station_address",
         "city",
@@ -179,13 +180,13 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(
                     "Both gas price polling and EV charging are disabled — nothing to fetch."
                 )
-            lat = self._subentry.data.get("latitude") or self.hass.config.latitude
-            lon = self._subentry.data.get("longitude") or self.hass.config.longitude
+            lat = self._subentry.data.get(CONF_LATITUDE) or self.hass.config.latitude
+            lon = self._subentry.data.get(CONF_LONGITUDE) or self.hass.config.longitude
             self._data = {
                 "station_id": self._subentry.data[CONF_STATION_ID],
                 "name": self._subentry.data.get(CONF_NAME, "EV Station"),
-                "latitude": lat,
-                "longitude": lon,
+                CONF_LATITUDE: lat,
+                CONF_LONGITUDE: lon,
             }
             _LOGGER.debug(
                 "fetch_gas disabled — bootstrapping EV-only data: %s",
@@ -195,11 +196,11 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
             try:
                 self._data = await self._api.price_lookup()
                 _LOGGER.debug("Gas station data: %s", _redact(self._data))
-                config_lat = self._subentry.data.get("latitude")
-                config_lon = self._subentry.data.get("longitude")
+                config_lat = self._subentry.data.get(CONF_LATITUDE)
+                config_lon = self._subentry.data.get(CONF_LONGITUDE)
                 if config_lat is not None and config_lon is not None:
-                    gas_lat = self._data.get("latitude")
-                    gas_lon = self._data.get("longitude")
+                    gas_lat = self._data.get(CONF_LATITUDE)
+                    gas_lon = self._data.get(CONF_LONGITUDE)
                     if gas_lat is not None and gas_lon is not None:
                         if abs(gas_lat - config_lat) > 1.0 or _lon_delta(gas_lon, config_lon) > 1.0:
                             raise APIError("Station ID collision detected")  # noqa: TRY301
@@ -208,8 +209,8 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.warning("Price lookup failed, trying EV station fallback: %s", ex)
                     try:
                         # Use coordinates from subentry if available, otherwise home coordinates
-                        lat = self._subentry.data.get("latitude")
-                        lon = self._subentry.data.get("longitude")
+                        lat = self._subentry.data.get(CONF_LATITUDE)
+                        lon = self._subentry.data.get(CONF_LONGITUDE)
                         if lat is None:
                             lat = self.hass.config.latitude
                         if lon is None:
@@ -250,19 +251,19 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                             self._data = {
                                 "station_id": matching["station_id"],
                                 "name": matching["name"],
-                                "latitude": matching["latitude"],
-                                "longitude": matching["longitude"],
+                                CONF_LATITUDE: matching["latitude"],
+                                CONF_LONGITUDE: matching["longitude"],
                                 **carried,
                             }
                             # Update subentry data if coordinates are new or changed
                             if (
-                                self._subentry.data.get("latitude") != matching["latitude"]
-                                or self._subentry.data.get("longitude") != matching["longitude"]
+                                self._subentry.data.get(CONF_LATITUDE) != matching["latitude"]
+                                or self._subentry.data.get(CONF_LONGITUDE) != matching["longitude"]
                             ):
                                 new_data = {
                                     **self._subentry.data,
-                                    "latitude": matching["latitude"],
-                                    "longitude": matching["longitude"],
+                                    CONF_LATITUDE: matching["latitude"],
+                                    CONF_LONGITUDE: matching["longitude"],
                                 }
                                 self.hass.config_entries.async_update_subentry(
                                     self._config, self._subentry, data=new_data
@@ -271,8 +272,8 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                             self._data = {
                                 "station_id": self._subentry.data[CONF_STATION_ID],
                                 "name": self._subentry.data.get(CONF_NAME, "EV Station"),
-                                "latitude": lat,
-                                "longitude": lon,
+                                CONF_LATITUDE: lat,
+                                CONF_LONGITUDE: lon,
                                 **carried,
                             }
                     except Exception as fallback_ex:  # noqa: BLE001
@@ -285,11 +286,11 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed from exception
 
         # Query EV station details if enabled
-        if ev_charging_enabled and "latitude" in self._data and "longitude" in self._data:
+        if ev_charging_enabled and CONF_LATITUDE in self._data and CONF_LONGITUDE in self._data:
             try:
                 ev_res = await self._api.ev_stations_nearby(
-                    lat=self._data["latitude"],
-                    lon=self._data["longitude"],
+                    lat=self._data[CONF_LATITUDE],
+                    lon=self._data[CONF_LONGITUDE],
                     radius=5,
                     limit=10,
                 )
@@ -363,9 +364,9 @@ class GasBuddyUpdateCoordinator(DataUpdateCoordinator):
         lat: float | None = None
         lon: float | None = None
         if not postal:
-            config_lat = self._subentry.data.get("latitude")
+            config_lat = self._subentry.data.get(CONF_LATITUDE)
             lat = config_lat if config_lat is not None else self.hass.config.latitude
-            config_lon = self._subentry.data.get("longitude")
+            config_lon = self._subentry.data.get(CONF_LONGITUDE)
             lon = config_lon if config_lon is not None else self.hass.config.longitude
 
         try:

--- a/custom_components/gasbuddy/diagnostics.py
+++ b/custom_components/gasbuddy/diagnostics.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
@@ -14,8 +15,8 @@ from .const import CONF_POSTAL, CONF_SOLVER, COORDINATOR, DOMAIN
 REDACT_KEYS = {
     CONF_SOLVER,
     CONF_POSTAL,
-    "latitude",
-    "longitude",
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
     "street_address",
     "ev_station_address",
     "city",

--- a/custom_components/gasbuddy/strings.json
+++ b/custom_components/gasbuddy/strings.json
@@ -74,7 +74,13 @@
                     "description": "Please enter the Station ID",
                     "data": {
                         "station_id": "Station ID",
-                        "name": "Name"
+                        "name": "Name",
+                        "interval": "Polling interval",
+                        "uom": "Show per liter/gallon in unit of measure",
+                        "gps": "Show stations on map",
+                        "ev_charging": "Enable EV charging sensors",
+                        "fetch_gas": "Fetch Gas Prices",
+                        "show_discounted": "Display discounted price"
                     }
                 },
                 "search": {
@@ -130,7 +136,13 @@
                     "description": "Please enter the configuration details for this entry",
                     "data": {
                         "station_id": "Station ID",
-                        "name": "Name"
+                        "name": "Name",
+                        "interval": "Polling interval",
+                        "uom": "Show per liter/gallon in unit of measure",
+                        "gps": "Show stations on map",
+                        "ev_charging": "Enable EV charging sensors",
+                        "fetch_gas": "Fetch Gas Prices",
+                        "show_discounted": "Display discounted price"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/custom_components/gasbuddy/translations/en.json
+++ b/custom_components/gasbuddy/translations/en.json
@@ -28,96 +28,6 @@
                     "timeout": "FlareSolverr timeout (ms)",
                     "brand_adjustments": "Brand Price Adjustments"
                 }
-            },
-            "user": {
-                "description": "Please select either manual station ID or search for a station.",
-                "menu_options": {
-                    "manual": "Enter Station ID Manually",
-                    "search": "Search for a station nearby",
-                    "cheapest": "Track cheapest nearby gas",
-                    "hub": "Configure Virtual Hub (Global Settings)"
-                }
-            },
-            "manual": {
-                "description": "Please enter the Station ID",
-                "data": {
-                    "station_id": "Station ID",
-                    "name": "Name"
-                }
-            },
-            "hub": {
-                "description": "Configure the Virtual Hub to manage settings globally across all stations. Brand price adjustments are entered in YAML format.",
-                "data": {
-                    "solver": "FlareSolverr URL (optional)",
-                    "timeout": "FlareSolverr timeout (ms)",
-                    "brand_adjustments": "Brand Price Adjustments"
-                }
-            },
-            "search": {
-                "description": "Search by your configured GPS location or by Postal Code",
-                "menu_options": {
-                    "home": "Use Home Assistant configured coordinates",
-                    "postal": "Use postal code (zip code)"
-                }
-            },
-            "home": {
-                "description": "Please select a station"
-            },
-            "postal": {
-                "description": "Please enter a postal code (zip code)",
-                "data": {
-                    "zipcode": "Postal Code (zip code)"
-                }
-            },
-            "station_list": {
-                "description": "Please select a station",
-                "data": {
-                    "station_id": "Station",
-                    "name": "Name"
-                }
-            },
-            "cheapest": {
-                "description": "Track the cheapest nearby gas station. Uses your home coordinates or a postal code. On every refresh the coordinator re-checks and updates to the current cheapest station.",
-                "data": {
-                    "name": "Name",
-                    "zipcode": "Postal Code (optional — leave blank to use HA home coordinates)",
-                    "fuel_key": "Fuel type",
-                    "price_type": "Price type"
-                }
-            },
-            "reconfigure": {
-                "description": "Please enter the Station ID",
-                "data": {
-                    "station_id": "Station ID",
-                    "name": "Name"
-                }
-            },
-            "cheapest_filters": {
-                "description": "Configure brand and station filters to restrict which stations are tracked. See [documentation]({brand_adjustments_url}) for brand price adjustment examples.",
-                "data": {
-                    "exclude_brands": "Excluded Brands",
-                    "include_brands": "Included Brands",
-                    "exclude_stations": "Excluded Stations",
-                    "include_stations": "Included Stations",
-                    "brand_adjustments": "Brand Price Adjustments"
-                }
-            },
-            "reconfigure_cheapest_filters": {
-                "description": "Configure brand and station filters to restrict which stations are tracked. See [documentation]({brand_adjustments_url}) for brand price adjustment examples.",
-                "data": {
-                    "exclude_brands": "Excluded Brands",
-                    "include_brands": "Included Brands",
-                    "exclude_stations": "Excluded Stations",
-                    "include_stations": "Included Stations",
-                    "brand_adjustments": "Brand Price Adjustments"
-                }
-            },
-            "home2": {
-                "description": "Please select a station",
-                "data": {
-                    "station_id": "Station",
-                    "name": "Name"
-                }
             }
         }
     },
@@ -164,7 +74,13 @@
                     "description": "Please enter the Station ID",
                     "data": {
                         "station_id": "Station ID",
-                        "name": "Name"
+                        "name": "Name",
+                        "interval": "Polling interval",
+                        "uom": "Show per liter/gallon in unit of measure",
+                        "gps": "Show stations on map",
+                        "ev_charging": "Enable EV charging sensors",
+                        "fetch_gas": "Fetch Gas Prices",
+                        "show_discounted": "Display discounted price"
                     }
                 },
                 "search": {
@@ -217,10 +133,16 @@
                     }
                 },
                 "reconfigure": {
-                    "description": "Please enter the Station ID",
+                    "description": "Please enter the configuration details for this entry",
                     "data": {
                         "station_id": "Station ID",
-                        "name": "Name"
+                        "name": "Name",
+                        "interval": "Polling interval",
+                        "uom": "Show per liter/gallon in unit of measure",
+                        "gps": "Show stations on map",
+                        "ev_charging": "Enable EV charging sensors",
+                        "fetch_gas": "Fetch Gas Prices",
+                        "show_discounted": "Display discounted price"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/custom_components/gasbuddy/translations/es.json
+++ b/custom_components/gasbuddy/translations/es.json
@@ -76,7 +76,7 @@
                         "station_id": "ID de Estación",
                         "name": "Nombre",
                         "interval": "Intervalo de actualización",
-                        "uom": "Mostrar por litro/galão en la unidad de medida",
+                        "uom": "Mostrar por litro/galón en la unidad de medida",
                         "gps": "Mostrar estaciones en el mapa",
                         "ev_charging": "Activar sensores de carga EV",
                         "fetch_gas": "Obtener precios de combustible",
@@ -133,16 +133,16 @@
                     }
                 },
                 "reconfigure": {
-                    "description": "Por favor, ingrese el ID de la estación",
+                    "description": "Por favor, ingrese los detalles de configuración de esta entrada",
                     "data": {
                         "station_id": "ID de Estación",
                         "name": "Nombre",
                         "interval": "Intervalo de actualización",
-                        "uom": "Mostrar por litro/galão en la unidad de medida",
+                        "uom": "Mostrar por litro/galón en la unidad de medida",
                         "gps": "Mostrar estaciones en el mapa",
                         "ev_charging": "Activar sensores de carga EV",
                         "fetch_gas": "Obtener precios de combustible",
-                        "show_discounted": "Mostrar precio con desconto"
+                        "show_discounted": "Mostrar precio con descuento"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/custom_components/gasbuddy/translations/es.json
+++ b/custom_components/gasbuddy/translations/es.json
@@ -74,7 +74,13 @@
                     "description": "Por favor, ingrese el ID de la estación",
                     "data": {
                         "station_id": "ID de Estación",
-                        "name": "Nombre"
+                        "name": "Nombre",
+                        "interval": "Intervalo de actualización",
+                        "uom": "Mostrar por litro/galão en la unidad de medida",
+                        "gps": "Mostrar estaciones en el mapa",
+                        "ev_charging": "Activar sensores de carga EV",
+                        "fetch_gas": "Obtener precios de combustible",
+                        "show_discounted": "Mostrar precio con descuento"
                     }
                 },
                 "search": {
@@ -130,7 +136,13 @@
                     "description": "Por favor, ingrese el ID de la estación",
                     "data": {
                         "station_id": "ID de Estación",
-                        "name": "Nombre"
+                        "name": "Nombre",
+                        "interval": "Intervalo de actualización",
+                        "uom": "Mostrar por litro/galão en la unidad de medida",
+                        "gps": "Mostrar estaciones en el mapa",
+                        "ev_charging": "Activar sensores de carga EV",
+                        "fetch_gas": "Obtener precios de combustible",
+                        "show_discounted": "Mostrar precio con desconto"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -74,7 +74,13 @@
                     "description": "Veuillez saisir l'ID de la station",
                     "data": {
                         "station_id": "Identifiant de la station",
-                        "name": "Nom"
+                        "name": "Nom",
+                        "interval": "Intervalle de mise à jour",
+                        "uom": "Afficher par litre/gallon dans l'unité de mesure",
+                        "gps": "Afficher les stations sur la carte",
+                        "ev_charging": "Activer les capteurs de recharge EV",
+                        "fetch_gas": "Récupérer les prix du carburant",
+                        "show_discounted": "Afficher le prix réduit"
                     }
                 },
                 "search": {
@@ -130,7 +136,13 @@
                     "description": "Veuillez entrer l'identifiant de la station",
                     "data": {
                         "station_id": "Identifiant de la station",
-                        "name": "Nom"
+                        "name": "Nom",
+                        "interval": "Intervalle de mise à jour",
+                        "uom": "Afficher par litre/gallon dans l'unité de mesure",
+                        "gps": "Afficher les stations sur la carte",
+                        "ev_charging": "Activer les capteurs de recharge EV",
+                        "fetch_gas": "Récupérer les prix du carburant",
+                        "show_discounted": "Afficher le prix réduit"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/custom_components/gasbuddy/translations/fr.json
+++ b/custom_components/gasbuddy/translations/fr.json
@@ -133,7 +133,7 @@
                     }
                 },
                 "reconfigure": {
-                    "description": "Veuillez entrer l'identifiant de la station",
+                    "description": "Veuillez entrer les détails de configuration pour cette entrée",
                     "data": {
                         "station_id": "Identifiant de la station",
                         "name": "Nom",

--- a/custom_components/gasbuddy/translations/pt.json
+++ b/custom_components/gasbuddy/translations/pt.json
@@ -74,7 +74,13 @@
                     "description": "Por favor, insira o ID da estação",
                     "data": {
                         "station_id": "ID da Estação",
-                        "name": "Nome"
+                        "name": "Nome",
+                        "interval": "Intervalo de atualização",
+                        "uom": "Mostrar por litro/galão na unidade de medida",
+                        "gps": "Mostrar estações no mapa",
+                        "ev_charging": "Ativar sensores de recarga EV",
+                        "fetch_gas": "Buscar preços de combustível",
+                        "show_discounted": "Exibir preço com desconto"
                     }
                 },
                 "search": {
@@ -130,7 +136,13 @@
                     "description": "Por favor, preencha os detalhes de configuração desta entrada",
                     "data": {
                         "station_id": "ID da Estação",
-                        "name": "Nome"
+                        "name": "Nome",
+                        "interval": "Intervalo de atualização",
+                        "uom": "Mostrar por litro/galão na unidade de medida",
+                        "gps": "Mostrar estações no mapa",
+                        "ev_charging": "Ativar sensores de recarga EV",
+                        "fetch_gas": "Buscar preços de combustível",
+                        "show_discounted": "Exibir preço com desconto"
                     }
                 },
                 "reconfigure_cheapest_filters": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1472,7 +1472,7 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     legacy_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Legacy Station",
-        data={"name": "Legacy Station", "station_id": 999005},
+        data={"name": "Legacy Station", "station_id": 999005, CONF_UOM: False},
         options={CONF_SHOW_DISCOUNTED: True, CONF_INTERVAL: 1800},
         version=CONFIG_VER,
         unique_id="legacy_migration_test",
@@ -1487,3 +1487,4 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     sub = next(iter(updated_hub.subentries.values()))
     assert sub.data[CONF_SHOW_DISCOUNTED] is True
     assert sub.data[CONF_INTERVAL] == 1800
+    assert sub.data[CONF_UOM] is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1429,7 +1429,10 @@ async def test_validate_station_ev_cloudflare_blocked(hass):
     with (
         patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
         patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("CF Block")),
-        patch("custom_components.gasbuddy.config_flow._csrf_blocked_via_state", return_value=True),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            side_effect=[False, True],
+        ),
         pytest.raises(CloudflareBlocked),
     ):
         await validate_station(hass, "999001")
@@ -1487,3 +1490,122 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     sub = next(iter(updated_hub.subentries.values()))
     assert sub.data[CONF_SHOW_DISCOUNTED] is True
     assert sub.data[CONF_INTERVAL] == 1800
+
+
+async def test_validate_station_ev_non_cloudflare_error(hass):
+    """Test validate_station handles non-Cloudflare EV lookup errors."""
+    with (
+        patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
+        patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("Generic")),
+        patch(
+            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
+            side_effect=[False, False],
+        ),
+        pytest.raises(InvalidStation),
+    ):
+        await validate_station(hass, "999001")
+
+
+async def test_subentry_manual_gas_dict(hass):
+    """Test manual config flow when validation returns a gas station dictionary."""
+    hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (hub.entry_id, "station"),
+        context={"source": "user"},
+    )
+    assert result["type"] == FlowResultType.MENU
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {"next_step_id": "manual"},
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        return_value={"type": "gas", CONF_LATITUDE: 34.0, CONF_LONGITUDE: -118.0},
+    ):
+        res = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {
+                CONF_STATION_ID: "999001",
+                CONF_NAME: "Manual Gas",
+                CONF_INTERVAL: 3600,
+                CONF_UOM: True,
+                CONF_GPS: True,
+                CONF_EV_CHARGING: False,
+                CONF_FETCH_GAS: True,
+            },
+        )
+        assert res["type"] == FlowResultType.CREATE_ENTRY
+        assert res["data"][CONF_EV_CHARGING] is False
+        assert res["data"][CONF_FETCH_GAS] is True
+
+
+async def test_subentry_manual_ev_dict(hass):
+    """Test manual config flow when validation returns an EV station dictionary."""
+    hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (hub.entry_id, "station"),
+        context={"source": "user"},
+    )
+    assert result["type"] == FlowResultType.MENU
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        {"next_step_id": "manual"},
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        return_value={"type": "ev", CONF_LATITUDE: 34.0, CONF_LONGITUDE: -118.0},
+    ):
+        res = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {
+                CONF_STATION_ID: "999001",
+                CONF_NAME: "Manual EV",
+                CONF_INTERVAL: 3600,
+                CONF_UOM: True,
+                CONF_GPS: True,
+                CONF_EV_CHARGING: False,
+                CONF_FETCH_GAS: True,
+            },
+        )
+        assert res["type"] == FlowResultType.CREATE_ENTRY
+        assert res["data"][CONF_EV_CHARGING] is True
+        assert res["data"][CONF_FETCH_GAS] is False
+
+
+async def test_coordinator_none_coordinates(hass):
+    """Test coordinator handles missing/None coordinates by falling back to Home Assistant config."""
+    hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub.add_to_hass(hass)
+
+    subentry = config_entries.ConfigSubentry(
+        subentry_id="test_subentry_id_none_coords",
+        subentry_type="station",
+        title="None Coordinates Station",
+        data=MappingProxyType({
+            CONF_STATION_ID: "999001",
+            CONF_NAME: "None Coordinates Station",
+            CONF_LATITUDE: None,
+            CONF_LONGITUDE: None,
+            CONF_EV_CHARGING: True,
+            CONF_FETCH_GAS: False,
+        }),
+        unique_id="999001",
+    )
+    hass.config_entries.async_add_subentry(hub, subentry)
+
+    coordinator = GasBuddyUpdateCoordinator(hass, hub, subentry)
+    with patch("py_gasbuddy.GasBuddy.ev_stations_nearby", return_value={"stations": []}):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data[CONF_LATITUDE] == hass.config.latitude
+    assert data[CONF_LONGITUDE] == hass.config.longitude

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,7 @@ from custom_components.gasbuddy.const import (
     CONF_NAME,
     CONF_POSTAL,
     CONF_PRICE_TYPE,
+    CONF_SHOW_DISCOUNTED,
     CONF_SOLVER,
     CONF_STATION_ID,
     CONF_TIMEOUT,
@@ -318,6 +319,107 @@ async def test_subentry_reconfigure(hass):
         assert updated_sub.data[CONF_STATION_ID] == "999002"
         assert updated_sub.data["latitude"] == 34.0
         assert updated_sub.title == "Costco New"
+
+
+async def test_subentry_reconfigure_options(hass):
+    """Test reconfiguring station subentry options (both when ID changes and when it doesn't)."""
+    hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub.add_to_hass(hass)
+
+    # Initialize subentry with custom options
+    subentry = config_entries.ConfigSubentry(
+        subentry_id="test_subentry_id_opts",
+        subentry_type="station",
+        title="Costco Options",
+        data=MappingProxyType({
+            CONF_STATION_ID: "999001",
+            CONF_NAME: "Costco Options",
+            CONF_INTERVAL: 1800,
+            CONF_UOM: False,
+            CONF_GPS: False,
+            CONF_EV_CHARGING: True,
+            CONF_FETCH_GAS: False,
+            CONF_SHOW_DISCOUNTED: True,
+        }),
+        unique_id="999001",
+    )
+    hass.config_entries.async_add_subentry(hub, subentry)
+
+    # 1. Initiate reconfigure flow (without ID change, toggling options)
+    result = await hass.config_entries.subentries.async_init(
+        (hub.entry_id, "station"),
+        context={
+            "source": "reconfigure",
+            "unique_id": "999001",
+            "subentry_id": "test_subentry_id_opts",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    # Submit updated options (keeping ID same, but toggling other settings)
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        return_value={"type": "gas", "latitude": 33.45, "longitude": -112.50},
+    ):
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {
+                CONF_STATION_ID: "999001",
+                CONF_NAME: "Costco Options Updated",
+                CONF_INTERVAL: 7200,
+                CONF_UOM: True,
+                CONF_GPS: True,
+                CONF_EV_CHARGING: False,
+                CONF_FETCH_GAS: True,
+                CONF_SHOW_DISCOUNTED: False,
+            },
+        )
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        # Subentry updated and options preserved/updated rather than overwritten by validator
+        updated_sub = hub.subentries["test_subentry_id_opts"]
+        assert updated_sub.data[CONF_STATION_ID] == "999001"
+        assert updated_sub.data[CONF_INTERVAL] == 7200
+        assert updated_sub.data[CONF_UOM] is True
+        assert updated_sub.data[CONF_GPS] is True
+        assert updated_sub.data[CONF_EV_CHARGING] is False
+        assert updated_sub.data[CONF_FETCH_GAS] is True
+        assert updated_sub.data[CONF_SHOW_DISCOUNTED] is False
+        assert updated_sub.title == "Costco Options Updated"
+
+    # 2. Reconfigure station ID to a different one (should overwrite EV/gas settings)
+    result = await hass.config_entries.subentries.async_init(
+        (hub.entry_id, "station"),
+        context={
+            "source": "reconfigure",
+            "unique_id": "999001",
+            "subentry_id": "test_subentry_id_opts",
+        },
+    )
+    with patch(
+        "custom_components.gasbuddy.config_flow.validate_station",
+        return_value={"type": "ev", "latitude": 33.5, "longitude": -112.6},
+    ):
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {
+                CONF_STATION_ID: "999002",
+                CONF_NAME: "EV Station",
+                CONF_INTERVAL: 3600,
+                CONF_UOM: True,
+                CONF_GPS: True,
+                CONF_EV_CHARGING: False,  # overridden because ID changed
+                CONF_FETCH_GAS: True,  # overridden because ID changed
+                CONF_SHOW_DISCOUNTED: False,
+            },
+        )
+        assert result["type"] == FlowResultType.ABORT
+        updated_sub = hub.subentries["test_subentry_id_opts"]
+        assert updated_sub.data[CONF_STATION_ID] == "999002"
+        # Auto-detected ev station type overwrites values submitted:
+        assert updated_sub.data[CONF_EV_CHARGING] is True
+        assert updated_sub.data[CONF_FETCH_GAS] is False
 
 
 async def test_hub_options_flow(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1424,17 +1424,22 @@ async def test_search_flow_success_and_failures(hass):
         assert res["data"][CONF_EV_CHARGING] is False
 
 
-async def test_validate_station_ev_cloudflare_blocked(hass):
+async def test_validate_station_ev_cloudflare_blocked(hass, mock_aioclient):
     """Test validate_station raises CloudflareBlocked on EV lookup failure due to CF."""
-    with (
-        patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
-        patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("CF Block")),
-        patch(
-            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
-            side_effect=[False, True],
-        ),
-        pytest.raises(CloudflareBlocked),
-    ):
+    # 1. Price lookup (first client)
+    mock_aioclient.get(
+        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
+    )
+    mock_aioclient.post(
+        "https://www.gasbuddy.com/graphql",
+        status=200,
+        body='{"errors": [{"message": "Price lookup error"}]}',
+    )
+    # 2. EV lookup (second client) - mocked for both paths (cache hit or refresh)
+    mock_aioclient.get("https://www.gasbuddy.com/home", status=403)
+    mock_aioclient.post("https://www.gasbuddy.com/graphql", status=403)
+
+    with pytest.raises(CloudflareBlocked):
         await validate_station(hass, "999001")
 
 
@@ -1492,17 +1497,28 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     assert sub.data[CONF_INTERVAL] == 1800
 
 
-async def test_validate_station_ev_non_cloudflare_error(hass):
+async def test_validate_station_ev_non_cloudflare_error(hass, mock_aioclient):
     """Test validate_station handles non-Cloudflare EV lookup errors."""
-    with (
-        patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
-        patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("Generic")),
-        patch(
-            "custom_components.gasbuddy.config_flow._csrf_blocked_via_state",
-            side_effect=[False, False],
-        ),
-        pytest.raises(InvalidStation),
-    ):
+    # 1. Price lookup (first client)
+    mock_aioclient.get(
+        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
+    )
+    mock_aioclient.post(
+        "https://www.gasbuddy.com/graphql",
+        status=200,
+        body='{"errors": [{"message": "Price lookup error"}]}',
+    )
+    # 2. EV lookup (second client)
+    mock_aioclient.get(
+        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
+    )
+    mock_aioclient.post(
+        "https://www.gasbuddy.com/graphql",
+        status=200,
+        body='{"errors": [{"message": "Generic EV lookup error"}]}',
+    )
+
+    with pytest.raises(InvalidStation):
         await validate_station(hass, "999001")
 
 
@@ -1542,6 +1558,7 @@ async def test_subentry_manual_gas_dict(hass):
         assert res["type"] == FlowResultType.CREATE_ENTRY
         assert res["data"][CONF_EV_CHARGING] is False
         assert res["data"][CONF_FETCH_GAS] is True
+        assert res["data"][CONF_SHOW_DISCOUNTED] is False
 
 
 async def test_subentry_manual_ev_dict(hass):
@@ -1580,6 +1597,7 @@ async def test_subentry_manual_ev_dict(hass):
         assert res["type"] == FlowResultType.CREATE_ENTRY
         assert res["data"][CONF_EV_CHARGING] is True
         assert res["data"][CONF_FETCH_GAS] is False
+        assert res["data"][CONF_SHOW_DISCOUNTED] is False
 
 
 async def test_coordinator_none_coordinates(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1472,7 +1472,7 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     legacy_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Legacy Station",
-        data={"name": "Legacy Station", "station_id": 999005, CONF_UOM: False},
+        data={"name": "Legacy Station", "station_id": 999005},
         options={CONF_SHOW_DISCOUNTED: True, CONF_INTERVAL: 1800},
         version=CONFIG_VER,
         unique_id="legacy_migration_test",
@@ -1487,4 +1487,3 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     sub = next(iter(updated_hub.subentries.values()))
     assert sub.data[CONF_SHOW_DISCOUNTED] is True
     assert sub.data[CONF_INTERVAL] == 1800
-    assert sub.data[CONF_UOM] is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.gasbuddy.config_flow import CloudflareBlocked, InvalidStation
+from custom_components.gasbuddy import _async_migrate_legacy_entries  # noqa: PLC2701
+from custom_components.gasbuddy.config_flow import (
+    CloudflareBlocked,
+    InvalidStation,
+    validate_station,
+)
 from custom_components.gasbuddy.const import (
     CONF_BRAND_ADJUSTMENTS,
     CONF_CHEAPEST,
@@ -30,6 +35,7 @@ from custom_components.gasbuddy.const import (
     CONFIG_VER,
     DOMAIN,
 )
+from custom_components.gasbuddy.coordinator import GasBuddyUpdateCoordinator
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.data_entry_flow import FlowResultType
@@ -611,7 +617,6 @@ from custom_components.gasbuddy.config_flow import (  # noqa: E402
     _get_schema_options,  # noqa: PLC2701
     _get_station_list,  # noqa: PLC2701
     _lon_delta,  # noqa: PLC2701
-    validate_station,
 )
 
 
@@ -1421,8 +1426,6 @@ async def test_search_flow_success_and_failures(hass):
 
 async def test_validate_station_ev_cloudflare_blocked(hass):
     """Test validate_station raises CloudflareBlocked on EV lookup failure due to CF."""
-    from custom_components.gasbuddy.config_flow import validate_station  # noqa: PLC0415
-
     with (
         patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
         patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("CF Block")),
@@ -1434,8 +1437,6 @@ async def test_validate_station_ev_cloudflare_blocked(hass):
 
 async def test_coordinator_zero_coordinates(hass):
     """Test coordinator handles valid 0.0 coordinates correctly."""
-    from custom_components.gasbuddy.coordinator import GasBuddyUpdateCoordinator  # noqa: PLC0415
-
     hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
     hub.add_to_hass(hass)
 
@@ -1465,8 +1466,6 @@ async def test_coordinator_zero_coordinates(hass):
 
 async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
     """Test _async_migrate_legacy_entries preserves CONF_SHOW_DISCOUNTED."""
-    from custom_components.gasbuddy import _async_migrate_legacy_entries  # noqa: PLC0415, PLC2701
-
     hub_entry = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
     hub_entry.add_to_hass(hass)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,9 +27,11 @@ from custom_components.gasbuddy.const import (
     CONF_STATION_ID,
     CONF_TIMEOUT,
     CONF_UOM,
+    CONFIG_VER,
     DOMAIN,
 )
 from homeassistant import config_entries
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.data_entry_flow import FlowResultType
 
 pytestmark = pytest.mark.asyncio
@@ -319,6 +321,7 @@ async def test_subentry_reconfigure(hass):
         assert updated_sub.data[CONF_STATION_ID] == "999002"
         assert updated_sub.data["latitude"] == 34.0
         assert updated_sub.title == "Costco New"
+        assert updated_sub.unique_id == "999002"
 
 
 async def test_subentry_reconfigure_options(hass):
@@ -1414,3 +1417,74 @@ async def test_search_flow_success_and_failures(hass):
         )
         assert res["type"] == FlowResultType.CREATE_ENTRY
         assert res["data"][CONF_EV_CHARGING] is False
+
+
+async def test_validate_station_ev_cloudflare_blocked(hass):
+    """Test validate_station raises CloudflareBlocked on EV lookup failure due to CF."""
+    from custom_components.gasbuddy.config_flow import validate_station  # noqa: PLC0415
+
+    with (
+        patch("py_gasbuddy.GasBuddy.price_lookup", side_effect=LibraryError("Failed")),
+        patch("py_gasbuddy.GasBuddy.ev_stations_nearby", side_effect=LibraryError("CF Block")),
+        patch("custom_components.gasbuddy.config_flow._csrf_blocked_via_state", return_value=True),
+        pytest.raises(CloudflareBlocked),
+    ):
+        await validate_station(hass, "999001")
+
+
+async def test_coordinator_zero_coordinates(hass):
+    """Test coordinator handles valid 0.0 coordinates correctly."""
+    from custom_components.gasbuddy.coordinator import GasBuddyUpdateCoordinator  # noqa: PLC0415
+
+    hub = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub.add_to_hass(hass)
+
+    subentry = config_entries.ConfigSubentry(
+        subentry_id="test_subentry_id_zero",
+        subentry_type="station",
+        title="Zero Station",
+        data=MappingProxyType({
+            CONF_STATION_ID: "999001",
+            CONF_NAME: "Zero Station",
+            CONF_LATITUDE: 0.0,
+            CONF_LONGITUDE: 0.0,
+            CONF_EV_CHARGING: True,
+            CONF_FETCH_GAS: False,
+        }),
+        unique_id="999001",
+    )
+    hass.config_entries.async_add_subentry(hub, subentry)
+
+    coordinator = GasBuddyUpdateCoordinator(hass, hub, subentry)
+    with patch("py_gasbuddy.GasBuddy.ev_stations_nearby", return_value={"stations": []}):
+        data = await coordinator._async_update_data()  # noqa: SLF001
+
+    assert data[CONF_LATITUDE] == 0.0
+    assert data[CONF_LONGITUDE] == 0.0
+
+
+async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
+    """Test _async_migrate_legacy_entries preserves CONF_SHOW_DISCOUNTED."""
+    from custom_components.gasbuddy import _async_migrate_legacy_entries  # noqa: PLC0415, PLC2701
+
+    hub_entry = MockConfigEntry(domain=DOMAIN, unique_id="hub", data={CONF_NAME: "Hub"})
+    hub_entry.add_to_hass(hass)
+
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Legacy Station",
+        data={"name": "Legacy Station", "station_id": 999005},
+        options={CONF_SHOW_DISCOUNTED: True, CONF_INTERVAL: 1800},
+        version=CONFIG_VER,
+        unique_id="legacy_migration_test",
+    )
+    legacy_entry.add_to_hass(hass)
+
+    await _async_migrate_legacy_entries(hass, hub_entry)
+    await hass.async_block_till_done()
+
+    updated_hub = hass.config_entries.async_get_entry(hub_entry.entry_id)
+    assert len(updated_hub.subentries) == 1
+    sub = next(iter(updated_hub.subentries.values()))
+    assert sub.data[CONF_SHOW_DISCOUNTED] is True
+    assert sub.data[CONF_INTERVAL] == 1800


### PR DESCRIPTION
## Proposed change
This PR restores the configuration options (`interval`, `uom`, `gps`, `ev_charging`, `fetch_gas`, and `show_discounted`) for individual gas station subentries, making them editable in both manual addition and station reconfiguration forms.
Additionally, it refactors the integration code to import and use the standard Home Assistant Core constants `CONF_LATITUDE` and `CONF_LONGITUDE` from `homeassistant.const` instead of hardcoded `"latitude"` and `"longitude"` strings.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Additional information
- This PR fixes or closes issue:
- This PR is related to issue:

##

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more per-station setup options, including update interval, unit display, map display, EV charging, fuel-price fetching, and discounted-price visibility.
  * Expanded reconfiguration screens to let you review and update the full station setup.

* **Bug Fixes**
  * Improved location handling for station setup and updates, making saved coordinates more reliable.
  * Preserved discounted-price visibility settings during legacy upgrades.
  * Improved diagnostics privacy by consistently redacting location details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->