### PR TITLE
test: migrate tests from aioresponses to aioclient_mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You probably do not want to do this! Use the HACS method above unless you know w
 
 Since May 2025, GasBuddy implemented Cloudflare which may lead to blocking of requests to GasBuddy, and cause timeout and log errors. This would lead to the occasional missed data update to obtain the latest gas prices, along with log errors.
 
-To circumvent this, FlareSolverr can be used to bypass Cloudflare protection. FlareSolverr can be installed via [FlareSolverr standalone installation](https://github.com/FlareSolverr/FlareSolverr) or as a [FlareSolverr Home Assistant add-on](https://github.com/alexbelgium/hassio-addons/tree/master/flaresolverr). Once your FlareSolverr instance is up and running, you can re-configure your existing GasBuddy entries by clicking the 3 dots of each gas station entry and entering your FlareSolverr URL, i.e., `http://ip:port/v1`
+To circumvent this, FlareSolverr can be used to bypass Cloudflare protection. FlareSolverr can be installed via [FlareSolverr standalone installation](https://github.com/FlareSolverr/FlareSolverr) or as a [FlareSolverr Home Assistant add-on](https://github.com/alexbelgium/hassio-addons/tree/master/flaresolverr). Once your FlareSolverr instance is up and running, you can configure your FlareSolverr URL and timeout globally on the **GasBuddy Virtual Hub** by clicking **Configure** on the integration card.
 
 <img width="673" height="498" alt="image" src="https://github.com/user-attachments/assets/dbb7f99f-9f4d-4b2b-83c9-8419ba106a97" />
 
@@ -71,11 +71,20 @@ Configuration is done via the Home Assistant UI. When adding the integration, yo
 *   **Search by Postal Code**: Enter a specific Zip or Postal Code to find stations in that area.
 *   **Track Cheapest Nearby Gas**: Instead of a fixed station, follow whichever nearby station is currently cheapest for a fuel type and price type you choose (see [Cheapest gas tracker](#cheapest-gas-tracker)).
 
-You can configure the following options by clicking **Configure** on the integration card:
-*   **Polling interval**: Polling frequency in seconds.
+### Global Options (Virtual Hub)
+By clicking **Configure** on the main **GasBuddy Virtual Hub** integration card, you can manage global settings that apply across all tracked stations:
+*   **FlareSolverr URL**: The URL to your FlareSolverr instance.
+*   **FlareSolverr timeout**: Timeout value in milliseconds.
+*   **Brand Price Adjustments**: YAML or JSON map for per-brand discounts or markups (see [Brand Price Adjustments](#brand-price-adjustments)).
+
+### Station Options (Subentries)
+Tracked gas stations are managed as **subentries** under the GasBuddy Virtual Hub. You can configure station-specific settings by clicking **Reconfigure** next to the specific station subentry under the Virtual Hub device/integration card:
+*   **Polling interval**: Polling frequency in seconds (default is 3600).
 *   **Show per liter/gallon in unit of measure**: Standardizes price representation.
 *   **Show stations on map**: Enables rendering of stations on the Map panel.
 *   **Enable EV charging sensors**: Toggles dedicated EV charging sensors that report connector counts and charging power per connector type (see [Sensors](#sensors) for details).
+*   **Fetch Gas Prices**: Toggles retrieving fuel prices for the station.
+*   **Display discounted price**: Toggles showing the discounted price as the state value of the sensor (applying brand adjustments).
 
 ### Cheapest gas tracker
 
@@ -98,7 +107,7 @@ You can optionally configure inclusion and exclusion filters to restrict trackin
 
 You can configure price adjustments (e.g. discounts or markups) per brand when setting up the cheapest station or configuring the integration options for any tracked station. These adjustments apply when determining which station is cheapest or show up as the `discounted_price` attribute on the price sensors. By default, the reported state remains the actual retail price at the pump.
 
-If you want the sensor state value itself to show the discounted price, you can enable the **Display discounted price** option in the integration configure screen.
+If you want the sensor state value itself to show the discounted price, you can enable the **Display discounted price** option in the station's reconfigure screen.
 
 Specify adjustments as a YAML or JSON map, where the key is either the brand name (case-insensitive) or the brand ID, and the value is the adjustment amount (a negative number for a discount, or positive for a markup).
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest-homeassistant-custom-component==0.13.340
+pytest-homeassistant-custom-component==0.13.344
 black
 flake8
 mypy
@@ -8,7 +8,6 @@ isort
 pylint
 tox
 pytest
-aioresponses
 ruff
 pre-commit==4.6.0
 codespell==2.4.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import logging
 from types import MappingProxyType
 from unittest.mock import patch
 
-from aioresponses import aioresponses
 import pytest
 
 # Monkeypatch MockConfigEntry to convert non-hub GasBuddy entries to Hub + Subentry
@@ -262,10 +261,9 @@ def mock_gasbuddy_cheapest():
 
 
 @pytest.fixture
-def mock_aioclient():
+def mock_aioclient(aioclient_mock):
     """Fixture to mock aioclient calls."""
-    with aioresponses() as m:
-        yield m
+    return aioclient_mock
 
 
 @pytest.fixture(name="hub_entry")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMockResponse
+from yarl import URL
 
 from custom_components.gasbuddy import _async_migrate_legacy_entries  # noqa: PLC2701
 from custom_components.gasbuddy.config_flow import (
@@ -1426,18 +1428,31 @@ async def test_search_flow_success_and_failures(hass):
 
 async def test_validate_station_ev_cloudflare_blocked(hass, mock_aioclient):
     """Test validate_station raises CloudflareBlocked on EV lookup failure due to CF."""
+    calls = 0
+
+    async def side_effect(method, url, data):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return AiohttpClientMockResponse(
+                method,
+                URL(url),
+                status=200,
+                json={"errors": [{"message": "Price lookup error"}]},
+            )
+        return AiohttpClientMockResponse(
+            method,
+            URL(url),
+            status=403,
+        )
+
     # 1. Price lookup (first client)
     mock_aioclient.get(
-        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
+        "https://www.gasbuddy.com/home", status=200, text='window.gbcsrf = "test_csrf_token"'
     )
-    mock_aioclient.post(
-        "https://www.gasbuddy.com/graphql",
-        status=200,
-        body='{"errors": [{"message": "Price lookup error"}]}',
-    )
+    mock_aioclient.post("https://www.gasbuddy.com/graphql", side_effect=side_effect)
     # 2. EV lookup (second client) - mocked for both paths (cache hit or refresh)
     mock_aioclient.get("https://www.gasbuddy.com/home", status=403)
-    mock_aioclient.post("https://www.gasbuddy.com/graphql", status=403)
 
     with pytest.raises(CloudflareBlocked):
         await validate_station(hass, "999001")
@@ -1499,23 +1514,33 @@ async def test_legacy_migration_preserves_show_discounted(hass, mock_gasbuddy):
 
 async def test_validate_station_ev_non_cloudflare_error(hass, mock_aioclient):
     """Test validate_station handles non-Cloudflare EV lookup errors."""
+    calls = 0
+
+    async def side_effect(method, url, data):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return AiohttpClientMockResponse(
+                method,
+                URL(url),
+                status=200,
+                json={"errors": [{"message": "Price lookup error"}]},
+            )
+        return AiohttpClientMockResponse(
+            method,
+            URL(url),
+            status=200,
+            json={"errors": [{"message": "Generic EV lookup error"}]},
+        )
+
     # 1. Price lookup (first client)
     mock_aioclient.get(
-        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
+        "https://www.gasbuddy.com/home", status=200, text='window.gbcsrf = "test_csrf_token"'
     )
-    mock_aioclient.post(
-        "https://www.gasbuddy.com/graphql",
-        status=200,
-        body='{"errors": [{"message": "Price lookup error"}]}',
-    )
+    mock_aioclient.post("https://www.gasbuddy.com/graphql", side_effect=side_effect)
     # 2. EV lookup (second client)
     mock_aioclient.get(
-        "https://www.gasbuddy.com/home", status=200, body='window.gbcsrf = "test_csrf_token"'
-    )
-    mock_aioclient.post(
-        "https://www.gasbuddy.com/graphql",
-        status=200,
-        body='{"errors": [{"message": "Generic EV lookup error"}]}',
+        "https://www.gasbuddy.com/home", status=200, text='window.gbcsrf = "test_csrf_token"'
     )
 
     with pytest.raises(InvalidStation):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -278,9 +278,9 @@ async def test_coordinator_success(hass, mock_aioclient):
     )
     coordinator = GasBuddyUpdateCoordinator(hass, entry)
 
-    mock_aioclient.get("https://www.gasbuddy.com/home", status=200, body=load_fixture("index.html"))
+    mock_aioclient.get("https://www.gasbuddy.com/home", status=200, text=load_fixture("index.html"))
     mock_aioclient.post(
-        "https://www.gasbuddy.com/graphql", status=200, body=load_fixture("station.json")
+        "https://www.gasbuddy.com/graphql", status=200, text=load_fixture("station.json")
     )
 
     # This will call _async_update_data UNPATCHED
@@ -1161,14 +1161,11 @@ async def test_sensor_brand_adjustments_options(hass, mock_aioclient):
         }
     }
 
-    mock_aioclient.get(
-        "https://www.gasbuddy.com/home", status=200, body=load_fixture("index.html"), repeat=True
-    )
+    mock_aioclient.get("https://www.gasbuddy.com/home", status=200, text=load_fixture("index.html"))
     mock_aioclient.post(
         "https://www.gasbuddy.com/graphql",
         status=200,
-        body=json.dumps(graphql_response_usd),
-        repeat=True,
+        text=json.dumps(graphql_response_usd),
     )
 
     sub_data = {
@@ -1258,15 +1255,12 @@ async def test_sensor_brand_adjustments_options(hass, mock_aioclient):
         }
     }
 
-    mock_aioclient.clear()
-    mock_aioclient.get(
-        "https://www.gasbuddy.com/home", status=200, body=load_fixture("index.html"), repeat=True
-    )
+    mock_aioclient.clear_requests()
+    mock_aioclient.get("https://www.gasbuddy.com/home", status=200, text=load_fixture("index.html"))
     mock_aioclient.post(
         "https://www.gasbuddy.com/graphql",
         status=200,
-        body=json.dumps(graphql_response_cad),
-        repeat=True,
+        text=json.dumps(graphql_response_cad),
     )
 
     sub_cad_data = {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMockResponse
+from yarl import URL
 
 from custom_components.gasbuddy.const import (
     ATTR_DEVICE_ID,
@@ -44,22 +46,38 @@ async def test_lookup_gps(
         title="Gas Station",
         data=CONFIG_DATA,
     )
+    calls = 0
+
+    async def side_effect(method, url, data):
+        nonlocal calls
+        calls += 1
+        if calls in {1, 2, 3}:
+            return AiohttpClientMockResponse(
+                method,
+                URL(url),
+                status=200,
+                text=load_fixture("results.json"),
+            )
+        return AiohttpClientMockResponse(
+            method,
+            URL(url),
+            status=400,
+            text=r"¯\_(ツ)_/¯",
+        )
+
     mock_aioclient.get(
         GB_URL,
         status=200,
-        body=load_fixture("index.html"),
-        repeat=True,
+        text=load_fixture("index.html"),
     )
     mock_aioclient.post(
         SOLVER_URL,
         status=200,
-        body=load_fixture("solver_response.json"),
-        repeat=True,
+        text=load_fixture("solver_response.json"),
     )
     mock_aioclient.post(
         TEST_URL,
-        status=200,
-        body=load_fixture("results.json"),
+        side_effect=side_effect,
     )
 
     entry.add_to_hass(hass)
@@ -94,12 +112,6 @@ async def test_lookup_gps(
             == "2024-11-18T21:58:38.859Z"
         )
 
-        mock_aioclient.post(
-            TEST_URL,
-            status=200,
-            body=load_fixture("results.json"),
-        )
-
         response = await hass.services.async_call(
             DOMAIN,
             SERVICE_LOOKUP_GPS,
@@ -110,12 +122,6 @@ async def test_lookup_gps(
 
         assert len(response[entity_id]["results"]) == 10
 
-        mock_aioclient.post(
-            TEST_URL,
-            status=200,
-            body=load_fixture("results.json"),
-        )
-
         response = await hass.services.async_call(
             DOMAIN,
             SERVICE_LOOKUP_GPS,
@@ -125,12 +131,6 @@ async def test_lookup_gps(
         )
 
         assert len(response[entity_id]["results"]) == 10
-
-    mock_aioclient.post(
-        TEST_URL,
-        status=400,
-        body=r"¯\_(ツ)_/¯",
-    )
 
     with caplog.at_level(logging.DEBUG):
         response = await hass.services.async_call(
@@ -155,22 +155,38 @@ async def test_lookup_zip(
         title="Gas Station",
         data=CONFIG_DATA,
     )
+    calls_zip = 0
+
+    async def side_effect_zip(method, url, data):
+        nonlocal calls_zip
+        calls_zip += 1
+        if calls_zip in {1, 2}:
+            return AiohttpClientMockResponse(
+                method,
+                URL(url),
+                status=200,
+                text=load_fixture("results.json"),
+            )
+        return AiohttpClientMockResponse(
+            method,
+            URL(url),
+            status=400,
+            text=r"¯\_(ツ)_/¯",
+        )
+
     mock_aioclient.get(
         GB_URL,
         status=200,
-        body=load_fixture("index.html"),
-        repeat=True,
+        text=load_fixture("index.html"),
     )
     mock_aioclient.post(
         SOLVER_URL,
         status=200,
-        body=load_fixture("solver_response.json"),
-        repeat=True,
+        text=load_fixture("solver_response.json"),
     )
     mock_aioclient.post(
         TEST_URL,
-        status=200,
-        body=load_fixture("results.json"),
+        side_effect=side_effect_zip,
     )
 
     entry.add_to_hass(hass)
@@ -196,12 +212,6 @@ async def test_lookup_zip(
         assert response["trend"][1]["average_price"] == 3.11
         assert response["trend"][1]["lowest_price"] == 0
 
-    mock_aioclient.post(
-        TEST_URL,
-        status=200,
-        body=load_fixture("results.json"),
-    )
-
     with caplog.at_level(logging.DEBUG):
         response = await hass.services.async_call(
             DOMAIN,
@@ -220,12 +230,6 @@ async def test_lookup_zip(
         assert response["trend"][1]["area"] == "United States"
         assert response["trend"][1]["average_price"] == 3.11
         assert response["trend"][1]["lowest_price"] == 0
-
-    mock_aioclient.post(
-        TEST_URL,
-        status=400,
-        body=r"¯\_(ツ)_/¯",
-    )
 
     with caplog.at_level(logging.DEBUG):
         response = await hass.services.async_call(
@@ -254,13 +258,12 @@ async def test_clear_cache(
     mock_aioclient.get(
         GB_URL,
         status=200,
-        body=load_fixture("index.html"),
-        repeat=True,
+        text=load_fixture("index.html"),
     )
     mock_aioclient.post(
         TEST_URL,
         status=200,
-        body=load_fixture("results.json"),
+        text=load_fixture("results.json"),
     )
 
     entry.add_to_hass(hass)
@@ -372,8 +375,8 @@ async def test_clear_cache_no_config_entry(hass, mock_gasbuddy, mock_aioclient, 
 async def test_lookup_gps_missing_coordinates(hass, mock_gasbuddy, mock_aioclient, caplog):
     """lookup_gps warns and returns an empty result for an entity without coordinates."""
     entry = MockConfigEntry(domain=DOMAIN, title="Gas Station", data=CONFIG_DATA)
-    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
-    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("results.json"))
+    mock_aioclient.get(GB_URL, status=200, text=load_fixture("index.html"))
+    mock_aioclient.post(TEST_URL, status=200, text=load_fixture("results.json"))
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
This PR migrates the test suite of the GasBuddy integration from `aioresponses` to Home Assistant's built-in `aioclient_mock` fixture. This resolves an incompatibility with `aiohttp >= 3.14.0` where `aioresponses` failed during mock response initialization.

We also updated the `README.md` to clarify setting FlareSolverr globally on the Virtual Hub and managing station-specific settings via subentry reconfiguration.

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to PR 315

##

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [x] Documentation added/updated in `README.md`