### PR TITLE
docs: add national average price template sensor to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,33 @@ Service | Description | Arguments
 `gasbuddy.ev_lookup_zip` | Lookup nearby EV stations via ZIP/Postal code. | `zipcode` (Required), `limit` (Optional), `radius` (Optional), `solver` (Optional)
 `gasbuddy.clear_cache` | Clear the cache for specific device(s). | `device_id` (Required)
 
+## National Average Price / Trends
+
+Although the integration's standard sensors track specific physical stations, you can create a template sensor to track the national average gas price (or other regional trends) using the `gasbuddy.lookup_zip` service.
+
+To do this, add a trigger-based template sensor to your `configuration.yaml` (adjusting the postal code and polling interval to your preference):
+
+```yaml
+template:
+  - trigger:
+      - platform: time_pattern
+        hours: "/6" # Fetch data every 6 hours
+    action:
+      - action: gasbuddy.lookup_zip
+        data:
+          postal_code: "12345" # Replace with your postal code
+        response_variable: gasbuddy_data
+    sensor:
+      - name: "National Average Gas Price"
+        unique_id: national_average_gas_price
+        state: >
+          {{ (gasbuddy_data.trend | selectattr('area', 'eq', 'United States') | first).average_price }}
+        unit_of_measurement: "USD/gal"
+        attributes:
+          lowest_price: >
+            {{ (gasbuddy_data.trend | selectattr('area', 'eq', 'United States') | first).lowest_price }}
+```
+
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ template:
     action:
       - action: gasbuddy.lookup_zip
         data:
-          postal_code: "12345" # Replace with your US zip code
+          zipcode: "12345" # Replace with your US zip code
         response_variable: gasbuddy_data
     sensor:
       - name: "National Average Gas Price"
@@ -265,7 +265,7 @@ template:
     action:
       - action: gasbuddy.lookup_zip
         data:
-          postal_code: "M5V 2T6" # Replace with your Canadian postal code
+          zipcode: "M5V 2T6" # Replace with your Canadian postal code
         response_variable: gasbuddy_data
     sensor:
       - name: "Canada National Average Gas Price"

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Although the integration's standard sensors track specific physical stations, yo
 
 To do this, add a trigger-based template sensor to your `configuration.yaml` (adjusting the postal code and polling interval to your preference):
 
+### United States Example
 ```yaml
 template:
   - trigger:
@@ -242,7 +243,7 @@ template:
     action:
       - action: gasbuddy.lookup_zip
         data:
-          postal_code: "12345" # Replace with your postal code
+          postal_code: "12345" # Replace with your US zip code
         response_variable: gasbuddy_data
     sensor:
       - name: "National Average Gas Price"
@@ -253,6 +254,28 @@ template:
         attributes:
           lowest_price: >
             {{ (gasbuddy_data.trend | selectattr('area', 'eq', 'United States') | first).lowest_price }}
+```
+
+### Canada Example
+```yaml
+template:
+  - trigger:
+      - platform: time_pattern
+        hours: "/6" # Fetch data every 6 hours
+    action:
+      - action: gasbuddy.lookup_zip
+        data:
+          postal_code: "M5V 2T6" # Replace with your Canadian postal code
+        response_variable: gasbuddy_data
+    sensor:
+      - name: "Canada National Average Gas Price"
+        unique_id: canada_national_average_gas_price
+        state: >
+          {{ ((gasbuddy_data.trend | selectattr('area', 'eq', 'Canada') | first).average_price / 100) | round(3) }}
+        unit_of_measurement: "CAD/L"
+        attributes:
+          lowest_price: >
+            {{ ((gasbuddy_data.trend | selectattr('area', 'eq', 'Canada') | first).lowest_price / 100) | round(3) }}
 ```
 
 ## Contributions are welcome!


### PR DESCRIPTION
## Proposed change

Adds a new section to the README explaining how users can create a trigger-based template sensor to track the national average gas price (or other regional trends) using the `gasbuddy.lookup_zip` service.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #324
- This PR is related to issue:

##

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “National Average Price / Trends” guide with setup steps for a trigger-based template sensor.
  * Included a configuration example for fetching trend data and displaying U.S. average and lowest gas prices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->