### PR TITLE
chore: update release-drafter to v7.7.0

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -31,4 +31,4 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0


### PR DESCRIPTION
This PR updates the release-drafter workflow to version v7.7.0 to ensure compatibility with the latest release management recommendations. 

Fixes #361