### PR TITLE
chore: migrate release-drafter configuration to new schema (PR #1558)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,7 +89,7 @@ categories:
 autolabeler:
   - label: "breaking-change"
     title:
-      - '/^[^\\s!]+!(\\( [^)]+ \\))?:/i'
+      - '/^[^\\s!]+!(\\([^)]+\\))?:/i'
   - label: "feature"
     branch:
       - "feat-*"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,80 +3,128 @@ tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 categories:
+  # 1. Version Resolver Categories (New Schema)
+  - type: "version-resolver"
+    when:
+      labels:
+        - "breaking-change"
+    semver-increment: "major"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "feature"
+        - "enhancement"
+    semver-increment: "minor"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "bug"
+        - "fix"
+        - "bugfix"
+        - "performance"
+        - "refactor"
+        - "style"
+        - "build"
+        - "chore"
+        - "documentation"
+        - "CI"
+        - "test"
+        - "code-quality"
+        - "revert"
+    semver-increment: "patch"
+
+  - type: "version-resolver"
+    semver-increment: "patch" # Default fallback
+
+  # 2. Changelog Grouping Categories (Updated 'when' syntax)
   - title: "💥 Breaking Change 💥"
-    labels:
-      - "breaking-change"
+    when:
+      labels:
+        - "breaking-change"
+
   - title: "✨ New Features ✨"
-    labels:
-      - "enhancement"
-      - "feature"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+
   - title: "🐛 Bug Fixes 🐛"
-    labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
+    when:
+      labels:
+        - "fix"
+        - "bugfix"
+        - "bug"
+
   - title: "⚡ Performance ⚡"
-    labels:
-      - "performance"
+    when:
+      labels:
+        - "performance"
+
   - title: "🔧 Maintenance 🔧"
-    labels:
-      - "chore"
-      - "documentation"
-      - "maintenance"
-      - "repo"
-      - "dependencies"
-      - "github_actions"
-      - "refactor"
-      - "style"
-      - "build"
-      - "revert"
-      - "translations"
+    when:
+      labels:
+        - "chore"
+        - "documentation"
+        - "maintenance"
+        - "repo"
+        - "dependencies"
+        - "github_actions"
+        - "refactor"
+        - "style"
+        - "build"
+        - "revert"
+        - "translations"
     collapse-after: 1
+
   - title: "🎓 Code Quality 🎓"
-    labels:
-      - "code-quality"
-      - "CI"
-      - "test"
-      - "has-tests"
+    when:
+      labels:
+        - "code-quality"
+        - "CI"
+        - "test"
+        - "has-tests"
+
 autolabeler:
   - label: "breaking-change"
     title:
-      - '/^[a-z]+(\([^)]+\))?!:/i'
+      - '/^[^\\s!]+!(\\( [^)]+ \\))?:/i'
   - label: "feature"
     branch:
       - "feat-*"
       - "feature-*"
     title:
-      - '/^feat(\([^)]+\))?:/i'
+      - '/^feat(\\([^)]+\\))?:/i'
   - label: "bugfix"
     branch:
       - "fix-*"
       - "bugfix-*"
     title:
-      - '/^fix(\([^)]+\))?:/i'
+      - '/^fix(\\([^)]+\\))?:/i'
   - label: "refactor"
     branch:
       - "refactor-*"
     title:
-      - '/^refactor(\([^)]+\))?:/i'
+      - '/^refactor(\\([^)]+\\))?:/i'
   - label: "code-quality"
     branch:
       - "test-*"
     title:
-      - '/^test(\([^)]+\))?:/i'
+      - '/^test(\\([^)]+\\))?:/i'
   - label: "CI"
     title:
-      - '/^ci(\([^)]+\))?:/i'
+      - '/^ci(\\([^)]+\\))?:/i'
   - label: "chore"
     branch:
       - "chore-*"
     title:
-      - '/^chore(\([^)]+\))?:/i'
+      - '/^chore(\\([^)]+\\))?:/i'
   - label: "documentation"
     branch:
       - "docs-*"
     title:
-      - '/^docs(\([^)]+\))?:/i'
+      - '/^docs(\\([^)]+\\))?:/i'
     files:
       - "README.md"
       - "CONTRIBUTING.md"
@@ -84,16 +132,16 @@ autolabeler:
       - "docs/**/*"
   - label: "style"
     title:
-      - '/^style(\([^)]+\))?:/i'
+      - '/^style(\\([^)]+\\))?:/i'
   - label: "performance"
     title:
-      - '/^perf(\([^)]+\))?:/i'
+      - '/^perf(\\([^)]+\\))?:/i'
   - label: "revert"
     title:
-      - '/^revert(\([^)]+\))?:/i'
+      - '/^revert(\\([^)]+\\))?:/i'
   - label: "build"
     title:
-      - '/^build(\([^)]+\))?:/i'
+      - '/^build(\\([^)]+\\))?:/i'
   - label: "dependencies"
     branch:
       - "deps-*"
@@ -107,30 +155,6 @@ autolabeler:
   - label: "translations"
     files:
       - "custom_components/gasbuddy/translations/**/*"
-version-resolver:
-  major:
-    labels:
-      - "breaking-change"
-  minor:
-    labels:
-      - "feature"
-      - "enhancement"
-  patch:
-    labels:
-      - "bug"
-      - "fix"
-      - "bugfix"
-      - "performance"
-      - "refactor"
-      - "style"
-      - "build"
-      - "chore"
-      - "documentation"
-      - "CI"
-      - "test"
-      - "code-quality"
-      - "revert"
-  default: patch
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/ha-gasbuddy/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/ha-gasbuddy/releases/$RESOLVED_VERSION)
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -31,4 +31,4 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest-homeassistant-custom-component==0.13.339
+pytest-homeassistant-custom-component==0.13.340
 black
 flake8
 mypy


### PR DESCRIPTION
Migrate release-drafter configuration to the new schema defined in PR #1558.