### PR TITLE
chore(ci): update deprecated async_get_device calls to async_get_device_by_identifier

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -41,7 +41,10 @@ async def test_diagnostics(
     device_registry = dr.async_get(hass)
     # The integration registers devices via identifiers (DOMAIN, unique_id)
     # The unique_id of the subentry is 999001
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "999001")})
+    device = device_registry.async_get_device_by_identifier(
+        identifier=(DOMAIN, "999001"),
+        config_entry_id=entry.entry_id,
+    )
     assert device is not None
 
     device_diagnostics = await async_get_device_diagnostics(hass, entry, device)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -381,7 +381,10 @@ async def test_subentry_removal_cleanup(hass, mock_gasbuddy):
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
 
-    device = dev_reg.async_get_device(identifiers={(DOMAIN, subentry.subentry_id)})
+    device = dev_reg.async_get_device_by_identifier(
+        identifier=(DOMAIN, subentry.subentry_id),
+        config_entry_id=entry.entry_id,
+    )
     assert device is not None
     assert subentry.subentry_id in device.config_entries_subentries.get(entry.entry_id, set())
 
@@ -398,7 +401,13 @@ async def test_subentry_removal_cleanup(hass, mock_gasbuddy):
     await hass.async_block_till_done()
 
     # Verify device and entities are purged
-    assert dev_reg.async_get_device(identifiers={(DOMAIN, subentry.subentry_id)}) is None
+    assert (
+        dev_reg.async_get_device_by_identifier(
+            identifier=(DOMAIN, subentry.subentry_id),
+            config_entry_id=entry.entry_id,
+        )
+        is None
+    )
     entities_post = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
     sub_entities_post = [e for e in entities_post if e.config_subentry_id == subentry.subentry_id]
     assert len(sub_entities_post) == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1321,12 +1321,18 @@ async def test_sensor_device_registered_under_hub_entry(hass, mock_gasbuddy):
     device_registry = dr.async_get(hass)
 
     # Station device must exist, scoped to the subentry
-    station_device = device_registry.async_get_device(identifiers={(DOMAIN, "test_subentry_id")})
+    station_device = device_registry.async_get_device_by_identifier(
+        identifier=(DOMAIN, "test_subentry_id"),
+        config_entry_id=entry.entry_id,
+    )
     assert station_device is not None
     assert station_device.manufacturer == "GasBuddy"
 
     # No phantom hub device should exist
-    hub_device = device_registry.async_get_device(identifiers={(DOMAIN, "hub")})
+    hub_device = device_registry.async_get_device_by_identifier(
+        identifier=(DOMAIN, "hub"),
+        config_entry_id=entry.entry_id,
+    )
     assert hub_device is None
 
     # Station device has no via_device parent


### PR DESCRIPTION
## Proposed change
Update deprecated calls from `device_registry.async_get_device` to `device_registry.async_get_device_by_identifier` with explicit `config_entry_id` across unit test files (`test_diagnostics.py`, `test_init.py`, `test_sensor.py`).

In newer Home Assistant releases, calling `async_get_device` without specifying the config entry triggers a `RuntimeError` due to deprecation warnings being treated as errors.

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:

##

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/gasbuddy tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in `README.md`

If the code communicates with devices, web services, or third-party tools:

- [ ] The `manifest.json` file has all fields filled out correctly.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
